### PR TITLE
Shiny, tensorflow, latest-tags, collapsing env vars

### DIFF
--- a/compose/binder.yml
+++ b/compose/binder.yml
@@ -10,3 +10,8 @@ services:
     build:
       context: ..
       dockerfile: dockerfiles/Dockerfile_binder_devel
+  binder-latest:
+    image: rockerdev/binder:latest
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_binder_4.0.0

--- a/compose/core-4.0.0.yml
+++ b/compose/core-4.0.0.yml
@@ -26,3 +26,29 @@ services:
     build:
       context: ..
       dockerfile: dockerfiles/Dockerfile_verse_4.0.0
+  r-ver-latest:
+    image: rockerdev/r-ver:latest
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_r-ver_4.0.0
+  rstudio-latest:
+    image: rockerdev/rstudio:latest
+    depends_on:
+    - r-ver-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_rstudio_4.0.0
+  tidyverse-latest:
+    image: rockerdev/tidyverse:latest
+    depends_on:
+    - rstudio-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tidyverse_4.0.0
+  verse-latest:
+    image: rockerdev/verse:latest
+    depends_on:
+    - tidyverse-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_verse_4.0.0

--- a/compose/geospatial.yml
+++ b/compose/geospatial.yml
@@ -14,4 +14,4 @@ services:
     image: rockerdev/geospatial:latest
     build:
       context: ..
-      dockerfile: dockerfiles/Dockerfile_geospatial_latest
+      dockerfile: dockerfiles/Dockerfile_geospatial_4.0.0

--- a/compose/shiny-3.6.3.yml
+++ b/compose/shiny-3.6.3.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  shiny-3.6.3:
+    image: rockerdev/shiny:3.6.3
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny_3.6.3
+  shiny-verse-3.6.3:
+    image: rockerdev/shiny-verse:3.6.3
+    depends_on:
+    - shiny-3.6.3
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny-verse_3.6.3

--- a/compose/shiny-4.0.0.yml
+++ b/compose/shiny-4.0.0.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  shiny-4.0.0:
+    image: rockerdev/shiny:4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny_4.0.0
+  shiny-verse-4.0.0:
+    image: rockerdev/shiny-verse:4.0.0
+    depends_on:
+    - shiny-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny-verse_4.0.0
+  shiny-latest:
+    image: rockerdev/shiny:latest
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny_4.0.0
+  shiny-verse-latest:
+    image: rockerdev/shiny-verse:latest
+    depends_on:
+    - shiny-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_shiny-verse_4.0.0

--- a/compose/tensorflow-4.0.0-cuda10.2.yml
+++ b/compose/tensorflow-4.0.0-cuda10.2.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  r-ver-4.0.0-cuda10.2:
+    image: rockerdev/r-ver:4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.2
+  tensorflow-4.0.0-cuda10.2:
+    image: rockerdev/tensorflow:4.0.0-cuda10.2
+    depends_on:
+    - r-ver-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow_4.0.0-cuda10.2
+  tensorflow-geo-4.0.0-cuda10.2:
+    image: rockerdev/tensorflow-geo:4.0.0-cuda10.2
+    depends_on:
+    - tensorflow-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-geo_4.0.0-cuda10.2

--- a/compose/tensorflow-4.0.0.yml
+++ b/compose/tensorflow-4.0.0.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  tensorflow-4.0.0:
+    image: rockerdev/tensorflow:4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow_4.0.0
+  tensorflow-geo-4.0.0:
+    image: rockerdev/tensorflow-geo:4.0.0
+    depends_on:
+    - tensorflow-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-geo_4.0.0
+  tensorflow-latest:
+    image: rockerdev/tensorflow:latest
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow_4.0.0
+  tensorflow-geo-latest:
+    image: rockerdev/tensorflow-geo:latest
+    depends_on:
+    - tensorflow-4.0.0
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-geo_4.0.0

--- a/compose/tensorflow-gpu-4.0.0-cuda10.2.yml
+++ b/compose/tensorflow-gpu-4.0.0-cuda10.2.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+  r-ver-gpu-4.0.0-cuda10.2:
+    image: rockerdev/r-ver-gpu:4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_r-ver-gpu_4.0.0-cuda10.2
+  tensorflow-gpu-4.0.0-cuda10.2:
+    image: rockerdev/tensorflow-gpu:4.0.0-cuda10.2
+    depends_on:
+    - r-ver-gpu-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-gpu_4.0.0-cuda10.2
+  tensorflow-geo-gpu-4.0.0-cuda10.2:
+    image: rockerdev/tensorflow-geo-gpu:4.0.0-cuda10.2
+    depends_on:
+    - tensorflow-gpu-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-geo-gpu_4.0.0-cuda10.2
+  r-ver-gpu-latest:
+    image: rockerdev/r-ver-gpu:latest
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_r-ver-gpu_4.0.0-cuda10.2
+  tensorflow-gpu-latest:
+    image: rockerdev/tensorflow-gpu:latest
+    depends_on:
+    - r-ver-gpu-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-gpu_4.0.0-cuda10.2
+  tensorflow-geo-gpu-latest:
+    image: rockerdev/tensorflow-geo-gpu:latest
+    depends_on:
+    - tensorflow-gpu-4.0.0-cuda10.2
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile_tensorflow-geo-gpu_4.0.0-cuda10.2

--- a/dockerfiles/Dockerfile_binder_4.0.0
+++ b/dockerfiles/Dockerfile_binder_4.0.0
@@ -1,5 +1,9 @@
-
 FROM rockerdev/geospatial:4.0.0
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_binder_devel
+++ b/dockerfiles/Dockerfile_binder_devel
@@ -1,5 +1,9 @@
-
 FROM rockerdev/geospatial:devel
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0
@@ -1,5 +1,9 @@
-
 FROM rockerdev/verse:4.0.0
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
@@ -1,5 +1,9 @@
-
 FROM rockerdev/verse:4.0.0-ubuntu18.04
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV UBUNTUGIS_VERSION=unstable
 

--- a/dockerfiles/Dockerfile_geospatial_devel
+++ b/dockerfiles/Dockerfile_geospatial_devel
@@ -1,5 +1,9 @@
-
 FROM rockerdev/verse:devel
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_latest
+++ b/dockerfiles/Dockerfile_geospatial_latest
@@ -1,5 +1,9 @@
-
 FROM rockerdev/geospatial:4.0.0
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_r-ver-gpu_4.0.0-cuda10.2
+++ b/dockerfiles/Dockerfile_r-ver-gpu_4.0.0-cuda10.2
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM nvidia/cuda:10.2-cudnn7-devel
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -10,11 +10,16 @@ ENV R_VERSION=4.0.0 \
     LC_ALL=en_US.UTF-8 \ 
     LANG=en_US.UTF-8 \ 
     R_HOME=/usr/local/lib/R \ 
-    CRAN=https://cran.r-project.org
+    CRAN=https://cran.r-project.org \ 
+    CUDA_HOME=/usr/local/cuda \ 
+    PATH=$PATH:$CUDA_HOME/bin \ 
+    LD_LIBRARY_PATH=$CUDA_HOME/lib64/libnvblas.so:$LD_LIBRARY_PATH:$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64 \ 
+    NVBLAS_CONFIG_FILE=/etc/nvblas.conf
 
 COPY scripts /rocker_scripts
 
 RUN /rocker_scripts/install_R.sh
+RUN /rocker_scripts/config_R_cuda.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
@@ -1,12 +1,16 @@
-
 FROM ubuntu:18.04
 
-ENV R_VERSION=3.6.3
-ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://mran.microsoft.com/snapshot/2020-04-24
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV R_VERSION=3.6.3 \ 
+    TERM=xterm \ 
+    LC_ALL=en_US.UTF-8 \ 
+    LANG=en_US.UTF-8 \ 
+    R_HOME=/usr/local/lib/R \ 
+    CRAN=https://mran.microsoft.com/snapshot/2020-04-24
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
@@ -1,12 +1,16 @@
-
 FROM ubuntu:18.04
 
-ENV R_VERSION=4.0.0
-ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://cran.r-project.org
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV R_VERSION=4.0.0 \ 
+    TERM=xterm \ 
+    LC_ALL=en_US.UTF-8 \ 
+    LANG=en_US.UTF-8 \ 
+    R_HOME=/usr/local/lib/R \ 
+    CRAN=https://cran.r-project.org
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/Dockerfile_r-ver_devel
+++ b/dockerfiles/Dockerfile_r-ver_devel
@@ -1,12 +1,16 @@
-
 FROM ubuntu:20.04
 
-ENV R_VERSION=devel
-ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://cran.r-project.org
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV R_VERSION=devel \ 
+    TERM=xterm \ 
+    LC_ALL=en_US.UTF-8 \ 
+    LANG=en_US.UTF-8 \ 
+    R_HOME=/usr/local/lib/R \ 
+    CRAN=https://cran.r-project.org
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
@@ -1,8 +1,12 @@
-
 FROM rockerdev/r-ver:3.6.3-ubuntu18.04
 
-ENV S6_VERSION=v1.21.7.0
-ENV RSTUDIO_VERSION=latest
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0 \ 
+    RSTUDIO_VERSION=latest
 
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/Dockerfile_rstudio_4.0.0
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0
@@ -1,8 +1,12 @@
-
 FROM rockerdev/r-ver:4.0.0
 
-ENV S6_VERSION=v1.21.7.0
-ENV RSTUDIO_VERSION=latest
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0 \ 
+    RSTUDIO_VERSION=latest
 
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
@@ -1,8 +1,12 @@
-
 FROM rockerdev/r-ver:4.0.0-ubuntu18.04
 
-ENV S6_VERSION=v1.21.7.0
-ENV RSTUDIO_VERSION=latest
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0 \ 
+    RSTUDIO_VERSION=latest
 
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/Dockerfile_rstudio_devel
+++ b/dockerfiles/Dockerfile_rstudio_devel
@@ -1,8 +1,12 @@
-
 FROM rockerdev/r-ver:devel
 
-ENV S6_VERSION=v1.21.7.0
-ENV RSTUDIO_VERSION=latest
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0 \ 
+    RSTUDIO_VERSION=latest
 
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/Dockerfile_shiny-verse_3.6.3
+++ b/dockerfiles/Dockerfile_shiny-verse_3.6.3
@@ -1,4 +1,4 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/shiny:3.6.3
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -7,7 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.0
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.0
@@ -1,4 +1,4 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/shiny:4.0.0
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -7,7 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_shiny_3.6.3
+++ b/dockerfiles/Dockerfile_shiny_3.6.3
@@ -1,15 +1,20 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/r-ver:3.6.3
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ENV S6_VERSION=v1.21.7.0 \ 
+    SHINY_SERVER_VERSION=latest \ 
+    PANDOC_VERSION=default
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN /rocker_scripts/install_shiny_server.sh
 
+EXPOSE 3838
 
+CMD /init
 
 
 

--- a/dockerfiles/Dockerfile_shiny_4.0.0
+++ b/dockerfiles/Dockerfile_shiny_4.0.0
@@ -1,15 +1,20 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/r-ver:4.0.0
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ENV S6_VERSION=v1.21.7.0 \ 
+    SHINY_SERVER_VERSION=latest \ 
+    PANDOC_VERSION=default
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN /rocker_scripts/install_shiny_server.sh
 
+EXPOSE 3838
 
+CMD /init
 
 
 

--- a/dockerfiles/Dockerfile_tensorflow-geo-gpu_4.0.0-cuda10.2
+++ b/dockerfiles/Dockerfile_tensorflow-geo-gpu_4.0.0-cuda10.2
@@ -1,4 +1,4 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/tensorflow-gpu:4.0.0-cuda10.2
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_tensorflow-geo_4.0.0
+++ b/dockerfiles/Dockerfile_tensorflow-geo_4.0.0
@@ -1,4 +1,4 @@
-FROM rockerdev/verse:4.0.0-ubuntu18.04
+FROM rockerdev/tensorflow:4.0.0
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_tensorflow-gpu_4.0.0-cuda10.2
+++ b/dockerfiles/Dockerfile_tensorflow-gpu_4.0.0-cuda10.2
@@ -1,0 +1,29 @@
+FROM rockerdev/r-ver-gpu:4.0.0-cuda10.2
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0 \ 
+    RSTUDIO_VERSION=latest \ 
+    PANDOC_VERSION=default \ 
+    WORKON_HOME=/opt/venv \ 
+    PYTHON_VENV_PATH=${WORKON_HOME}/reticulate \ 
+    RETICULATE_AUTOCONFIGURE=0 \ 
+    PATH=${PYTHON_VENV_PATH}/bin:${PATH} \ 
+    TENSORFLOW_VERSION=gpu \ 
+    KERAS_VERSION=default
+
+
+RUN /rocker_scripts/install_rstudio.sh
+RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_tidyverse.sh
+RUN /rocker_scripts/install_tensorflow.sh
+
+EXPOSE 8787
+
+CMD /init
+
+
+

--- a/dockerfiles/Dockerfile_tensorflow_4.0.0
+++ b/dockerfiles/Dockerfile_tensorflow_4.0.0
@@ -5,11 +5,15 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet \ 
-    PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
+ENV WORKON_HOME=/opt/venv \ 
+    PYTHON_VENV_PATH=${WORKON_HOME}/reticulate \ 
+    RETICULATE_AUTOCONFIGURE=0 \ 
+    PATH=${PYTHON_VENV_PATH}/bin:${PATH} \ 
+    TENSORFLOW_VERSION=cpu \ 
+    KERAS_VERSION=default
 
 
-RUN /rocker_scripts/install_verse.sh
+RUN /rocker_scripts/install_tensorflow.sh
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
@@ -1,5 +1,9 @@
-
 FROM rockerdev/rstudio:3.6.3-ubuntu18.04
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0
@@ -1,5 +1,9 @@
-
 FROM rockerdev/rstudio:4.0.0
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
@@ -1,5 +1,9 @@
-
 FROM rockerdev/rstudio:4.0.0-ubuntu18.04
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_devel
+++ b/dockerfiles/Dockerfile_tidyverse_devel
@@ -1,5 +1,9 @@
-
 FROM rockerdev/rstudio:devel
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
@@ -1,8 +1,12 @@
-
 FROM rockerdev/tidyverse:3.6.3-ubuntu18.04
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
-ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet \ 
+    PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
@@ -1,8 +1,12 @@
-
 FROM rockerdev/tidyverse:4.0.0-ubuntu18.04
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
-ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet \ 
+    PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/Dockerfile_verse_devel
+++ b/dockerfiles/Dockerfile_verse_devel
@@ -1,8 +1,12 @@
-
 FROM rockerdev/tidyverse:devel
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
-ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet \ 
+    PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
 RUN /rocker_scripts/install_verse.sh

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -15,7 +15,9 @@ paste_if <- function(element, image){
     return("")
   
   if(!is.null(names(value)))
-     out <- paste0(key, " ", names(value), "=", value, collapse = "\n")
+     out <- paste0(key, " ", (
+       paste0(names(value), "=", value, collapse = " \\ \n    "))
+     )
   else
     out <- paste0(key, " ", value, collapse = "\n")
   

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -30,8 +30,8 @@ write_dockerfiles <- function(stack, global){
     image <- inherit_global(image, global)
   
     body <- paste(c(
-      paste_if("LABEL", image),
       paste_if("FROM", image),
+      paste_if("LABEL", image),
       paste_if("ENV", image),
       paste_if("COPY", image),
       paste_if("RUN", image),

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Note that 'default' pandoc version means the version bundled with RStudio
+# if RStudio is installed , but latest otherwise
+
 PANDOC_VERSION=${1:-${PANDOC_VERSION:-default}}
 
 apt-get update && apt-get -y install wget

--- a/scripts/install_tensorflow.sh
+++ b/scripts/install_tensorflow.sh
@@ -4,6 +4,9 @@ set -e
 TENSORFLOW_VERSION=${1:-${TENSORFLOW_VERSION:-default}}
 KERAS_VERSION=${2:-${KERAS_VERSION:-default}}
 
+## Install python dependency
+/rocker_scripts/install_python.sh
+
 ## To support different version of TF, install to different virtualenvs
 TENSORFLOW_VENV=$PYTHON_VENV_PATH
 

--- a/stacks/binder.json
+++ b/stacks/binder.json
@@ -3,6 +3,7 @@
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
+    "latest": true,
     "IMAGE": "binder",
     "TAG": "4.0.0",
     "FROM": "rockerdev/geospatial:4.0.0",

--- a/stacks/binder.json
+++ b/stacks/binder.json
@@ -1,6 +1,6 @@
 {
-
 "ordered": false,
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/core-3.6.3-ubuntu18.04.json
+++ b/stacks/core-3.6.3-ubuntu18.04.json
@@ -1,6 +1,8 @@
 {
   "ordered": true,
   "TAG": "3.6.3-ubuntu18.04",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.0-ubuntu18.04.json
+++ b/stacks/core-4.0.0-ubuntu18.04.json
@@ -1,6 +1,8 @@
 {
   "ordered": true,
   "TAG": "4.0.0-ubuntu18.04",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.0.json
+++ b/stacks/core-4.0.0.json
@@ -1,6 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.0",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.0.json
+++ b/stacks/core-4.0.0.json
@@ -1,5 +1,6 @@
 {
   "ordered": true,
+  "latest": true,
   "TAG": "4.0.0",
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [

--- a/stacks/core-devel.json
+++ b/stacks/core-devel.json
@@ -1,6 +1,7 @@
 {
   "ordered": true,
   "TAG": "devel",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/geospatial-ubuntu18.04.json
+++ b/stacks/geospatial-ubuntu18.04.json
@@ -1,6 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.0-ubuntu18.04-unstable",

--- a/stacks/geospatial.json
+++ b/stacks/geospatial.json
@@ -5,6 +5,7 @@
 "stack": [
   {
     "TAG": "4.0.0",
+    "latest": true,
     "FROM": "rockerdev/verse:4.0.0",
     "RUN": "/rocker_scripts/install_geospatial.sh"
   },
@@ -12,10 +13,6 @@
     "TAG": "devel",
     "FROM": "rockerdev/verse:devel",
     "RUN": "/rocker_scripts/install_geospatial.sh"
-  },
-  {
-    "TAG": "latest",
-    "FROM": "rockerdev/geospatial:4.0.0"
   }
 ]
 

--- a/stacks/geospatial.json
+++ b/stacks/geospatial.json
@@ -1,6 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.0",

--- a/stacks/shiny-3.6.3.json
+++ b/stacks/shiny-3.6.3.json
@@ -1,0 +1,27 @@
+{
+  "ordered": true,
+  "TAG": "3.6.3",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "stack": [
+  {
+    "IMAGE": "shiny",
+    "FROM": "rockerdev/r-ver:3.6.3",
+    "ENV": {
+      "S6_VERSION": "v1.21.7.0",
+      "SHINY_SERVER_VERSION": "latest",
+      "PANDOC_VERSION": "default"
+    },
+    "RUN": "/rocker_scripts/install_shiny_server.sh",
+    "CMD": "/init",
+    "EXPOSE": 3838
+  },
+  {
+    "IMAGE": "shiny-verse",
+    "FROM": "rockerdev/shiny:3.6.3",
+    "RUN": "/rocker_scripts/install_tidyverse.sh"
+  }]
+}
+
+
+
+

--- a/stacks/shiny-4.0.0.json
+++ b/stacks/shiny-4.0.0.json
@@ -1,0 +1,27 @@
+{
+  "ordered": true,
+  "TAG": "4.0.0",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "stack": [
+  {
+    "IMAGE": "shiny",
+    "FROM": "rockerdev/r-ver:4.0.0",
+    "ENV": {
+      "S6_VERSION": "v1.21.7.0",
+      "SHINY_SERVER_VERSION": "latest",
+      "PANDOC_VERSION": "default"
+    },
+    "RUN": "/rocker_scripts/install_shiny_server.sh",
+    "CMD": "/init",
+    "EXPOSE": 3838
+  },
+  {
+    "IMAGE": "shiny-verse",
+    "FROM": "rockerdev/shiny:4.0.0",
+    "RUN": "/rocker_scripts/install_tidyverse.sh"
+  }]
+}
+
+
+
+

--- a/stacks/shiny-4.0.0.json
+++ b/stacks/shiny-4.0.0.json
@@ -1,5 +1,6 @@
 {
   "ordered": true,
+  "latest": true,
   "TAG": "4.0.0",
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [

--- a/stacks/tensorflow-4.0.0-cuda10.2.json
+++ b/stacks/tensorflow-4.0.0-cuda10.2.json
@@ -1,0 +1,63 @@
+{
+  "ordered": true,
+  "TAG": "4.0.0-cuda10.2",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "stack": [
+  {
+    "IMAGE": "r-ver",
+    "FROM": "nvidia/cuda:10.2-cudnn7-devel",
+    "ENV": {
+      "R_VERSION": "4.0.0",
+      "TERM": "xterm",
+      "LC_ALL": "en_US.UTF-8",
+      "LANG": "en_US.UTF-8",
+      "R_HOME": "/usr/local/lib/R",
+      "CRAN": "https://cran.r-project.org",
+      "CUDA_HOME": "/usr/local/cuda",
+      "PATH": "$PATH:$CUDA_HOME/bin",
+      "LD_LIBRARY_PATH": "$CUDA_HOME/lib64/libnvblas.so:$LD_LIBRARY_PATH:$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64",
+      "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf"
+    },
+    "COPY": "scripts /rocker_scripts",
+    "RUN": [
+      "/rocker_scripts/install_R.sh",
+      "/rocker_scripts/config_R_cuda.sh"
+    ],
+    "CMD": "R"
+  },
+  {
+    "IMAGE": "tensorflow",
+    "FROM": "rockerdev/r-ver:4.0.0-cuda10.2",
+    "ENV": {
+      "S6_VERSION": "v1.21.7.0",
+      "RSTUDIO_VERSION": "latest",
+      "PANDOC_VERSION": "default",
+      "WORKON_HOME": "/opt/venv",
+      "PYTHON_VENV_PATH": "${WORKON_HOME}/reticulate",
+      "RETICULATE_AUTOCONFIGURE": "0",
+      "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}",
+      "TENSORFLOW_VERSION": "gpu",
+      "KERAS_VERSION": "default"
+    },
+    "RUN": [
+      "/rocker_scripts/install_rstudio.sh",
+      "/rocker_scripts/install_pandoc.sh",
+      "/rocker_scripts/install_tidyverse.sh",
+      "/rocker_script/install_tensorflow"
+      ],
+    "CMD": "/init",
+    "EXPOSE": 8787
+  },
+  {
+    "IMAGE": "tensorflow-geo",
+    "FROM": "rockerdev/tensorflow:4.0.0-cuda10.2",
+    "RUN": [
+      "/rocker_scripts/install_verse.sh",
+      "/rocker_scripts/install_geospatial.sh"
+      ]
+  }]
+}
+
+
+
+

--- a/stacks/tensorflow-4.0.0.json
+++ b/stacks/tensorflow-4.0.0.json
@@ -15,7 +15,7 @@
       "TENSORFLOW_VERSION": "cpu",
       "KERAS_VERSION": "default"
     },
-    "RUN": "/rocker_script/install_tensorflow"
+    "RUN": "/rocker_scripts/install_tensorflow.sh"
   },
   {
     "IMAGE": "tensorflow-geo",

--- a/stacks/tensorflow-4.0.0.json
+++ b/stacks/tensorflow-4.0.0.json
@@ -1,0 +1,31 @@
+{
+  "ordered": true,
+  "TAG": "4.0.0",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "stack": [
+  {
+    "IMAGE": "tensorflow",
+    "FROM": "rockerdev/tidyverse:4.0.0",
+    "ENV": {
+      "WORKON_HOME": "/opt/venv",
+      "PYTHON_VENV_PATH": "${WORKON_HOME}/reticulate",
+      "RETICULATE_AUTOCONFIGURE": "0",
+      "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}",
+      "TENSORFLOW_VERSION": "cpu",
+      "KERAS_VERSION": "default"
+    },
+    "RUN": "/rocker_script/install_tensorflow"
+  },
+  {
+    "IMAGE": "tensorflow-geo",
+    "FROM": "rockerdev/tensorflow:4.0.0",
+    "RUN": [
+      "/rocker_scripts/install_verse.sh",
+      "/rocker_scripts/install_geospatial.sh"
+      ]
+  }]
+}
+
+
+
+

--- a/stacks/tensorflow-4.0.0.json
+++ b/stacks/tensorflow-4.0.0.json
@@ -1,5 +1,6 @@
 {
   "ordered": true,
+  "latest": true,
   "TAG": "4.0.0",
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [

--- a/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
+++ b/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
@@ -4,7 +4,7 @@
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
-    "IMAGE": "r-ver",
+    "IMAGE": "r-ver-gpu",
     "FROM": "nvidia/cuda:10.2-cudnn7-devel",
     "ENV": {
       "R_VERSION": "4.0.0",
@@ -26,8 +26,8 @@
     "CMD": "R"
   },
   {
-    "IMAGE": "tensorflow",
-    "FROM": "rockerdev/r-ver:4.0.0-cuda10.2",
+    "IMAGE": "tensorflow-gpu",
+    "FROM": "rockerdev/r-ver-gpu:4.0.0-cuda10.2",
     "ENV": {
       "S6_VERSION": "v1.21.7.0",
       "RSTUDIO_VERSION": "latest",
@@ -49,8 +49,8 @@
     "EXPOSE": 8787
   },
   {
-    "IMAGE": "tensorflow-geo",
-    "FROM": "rockerdev/tensorflow:4.0.0-cuda10.2",
+    "IMAGE": "tensorflow-geo-gpu",
+    "FROM": "rockerdev/tensorflow-gpu:4.0.0-cuda10.2",
     "RUN": [
       "/rocker_scripts/install_verse.sh",
       "/rocker_scripts/install_geospatial.sh"

--- a/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
+++ b/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
@@ -44,7 +44,7 @@
       "/rocker_scripts/install_rstudio.sh",
       "/rocker_scripts/install_pandoc.sh",
       "/rocker_scripts/install_tidyverse.sh",
-      "/rocker_script/install_tensorflow"
+      "/rocker_scripts/install_tensorflow.sh"
       ],
     "CMD": "/init",
     "EXPOSE": 8787

--- a/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
+++ b/stacks/tensorflow-gpu-4.0.0-cuda10.2.json
@@ -1,5 +1,6 @@
 {
   "ordered": true,
+  "latest": true,
   "TAG": "4.0.0-cuda10.2",
   "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [

--- a/write-compose.R
+++ b/write-compose.R
@@ -12,49 +12,54 @@ inherit_global <- function(image, global){
 #' We cannot necesarily build the FROM image first since our stack need
 #' not define the build rule for the FROM image. (Obviously that's true
 #' for the first image, but can be true for later images too).
+#' @param latest should tag "latest" be added to the image? 
 write_compose <- 
   function(json_file, out = "docker-compose.yml", org = "rocker"){
-
-        
+    
+    
     json <- yaml::read_yaml(json_file) #jsonlite::read_json(json_file)
     global <- json[ !(names(json) %in% c("ordered", "stack"))]
     json_stack <- lapply(json$stack, inherit_global, global)
     
+    ordered <- isTRUE(json$ordered)
     
-    
-    
-    ordered <- json$ordered
     prefix <- "dockerfiles/Dockerfile_"
     map_chr <- function(x, name) vapply(x, `[[`, character(1L), name)
+    map_lgl <- function(x, FUN) vapply(x, FUN, logical(1L))
     
     name <- map_chr(json_stack, "IMAGE")
     tag <-  map_chr(json_stack, "TAG")
+    latest <- map_lgl(json_stack, function(z) isTRUE(z[["latest"]]))
     
     dockerfiles <- paste0(prefix, name, "_", tag)
     names(dockerfiles) <- name
-   
-     
-    image_name <- function(d, org){
+    
+    image_name <- function(d, org, latest=FALSE){
       x <- gsub(prefix, "", d)
       x <- gsub("_", ":", x)
-      paste(org, x, sep="/")
+      if (latest) x <- gsub(":.*$", ":latest", x)
+      paste(org, x, sep = "/")
+    }
+    service_name <- function(d, latest=FALSE){
+      x <- gsub(prefix, "", d)
+      if (latest) x <- gsub("_[^_]*$", "-latest", x)
     }
     
-    image <- paste(name, tag, sep="-")
-
+    image <- paste(name, tag, sep = "-")
+    
     ## we only enforce order if requested
     depends_on <- rep("", length(image))
-    if(ordered)
-      depends_on <- c("", image[1:(length(image)-1)])
+    if (ordered)
+      depends_on <- c("", image[1:(length(image) - 1)])
     
     
-    not_blank <- function(x) if(x == "") return(NULL) else x
+    not_blank <- function(x) if (x == "") return(NULL) else x
     is_empty <- function(x) length(x) == 0 || is.null(x)
-    compact <- function (l) Filter(Negate(is_empty), l)
+    compact <- function(l) Filter(Negate(is_empty), l)
     
     services <- vector("list", length(dockerfiles))
     names(services) <- image
-    for(i in seq_along(dockerfiles)){
+    for (i in seq_along(dockerfiles)) {
       d <- dockerfiles[[i]] 
       services[[i]] <- compact(list(
         image = image_name(d, org),
@@ -64,6 +69,18 @@ write_compose <-
           dockerfile = d
         )
       ))
+      if (latest[i]) {
+        latest_entry <- list(compact(list(
+          image = image_name(d, org, latest = TRUE),
+          depends_on = compact(list(not_blank(depends_on[i]))),
+          build = list(
+            context = "..",
+            dockerfile = d
+          )
+        )))
+        names(latest_entry) <- service_name(d, latest = TRUE)
+        services <- c(services, latest_entry)
+      }
     }
     
     
@@ -72,8 +89,8 @@ write_compose <-
       services =  services
     )
     yaml::write_yaml(compose, out)
-  
-  message(paste(out))  
+    
+    message(paste(out))  
   }
 
 


### PR DESCRIPTION
Still some things to tweak, but I have to do some other things this afternoon and wanted you to have the latest.  In this PR

- Shiny 3.6.3 and 4.0.0 stacks
- Tensorflow cpu and gpu stacks
- Now adding "latest: true" to any image in the stackfiles (local or global) will result in it getting a ":latest" in the compose files.
- ENV vars are now collapsed so they are set in a single image layer.