### PR TITLE
Initial work on building with Builkit and ccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ STACKFILES=$(wildcard stacks/*.json)
 STACKS=$(notdir $(basename $(STACKFILES)))
 COMPOSEFILES=$(addprefix compose/,$(addsuffix .yml,$(STACKS)))
 PUSHES=$(addsuffix .push,$(STACKS))
+BUILDKIT_CACHE=0
 
 .PHONY: clean build setup push
 .PHONY: $(STACKS) $(PUSHES)
@@ -16,7 +17,7 @@ $(COMPOSEFILES): make-dockerfiles.R write-compose.R $(STACKFILES)
 build: $(STACKS)
 
 $(STACKS): %: compose/%.yml
-	docker-compose -f compose/$@.yml build
+	COMPOSE_DOCKER_CLI_BUILD=$(BUILDKIT_CACHE) DOCKER_BUILDKIT=$(BUILDKIT_CACHE) docker-compose -f compose/$@.yml build
 
 binder: geospatial
 

--- a/dockerfiles/Dockerfile_binder_4.0.0
+++ b/dockerfiles/Dockerfile_binder_4.0.0
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 

--- a/dockerfiles/Dockerfile_binder_4.0.0
+++ b/dockerfiles/Dockerfile_binder_4.0.0
@@ -1,15 +1,23 @@
+<<<<<<< HEAD
 FROM rocker/geospatial:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/geospatial:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_python.sh
-RUN /rocker_scripts/install_binder.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_python.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_binder.sh
 
 
 

--- a/dockerfiles/Dockerfile_binder_devel
+++ b/dockerfiles/Dockerfile_binder_devel
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 

--- a/dockerfiles/Dockerfile_binder_devel
+++ b/dockerfiles/Dockerfile_binder_devel
@@ -1,15 +1,23 @@
+<<<<<<< HEAD
 FROM rocker/geospatial:devel
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/geospatial:devel
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_python.sh
-RUN /rocker_scripts/install_binder.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_python.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_binder.sh
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/verse:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/verse:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_geospatial.sh
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/verse:4.0.0-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/verse:4.0.0-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_geospatial.sh
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV UBUNTUGIS_VERSION=unstable
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04-unstable
@@ -1,16 +1,24 @@
+<<<<<<< HEAD
 FROM rocker/verse:4.0.0-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/verse:4.0.0-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV UBUNTUGIS_VERSION=unstable
 
 
-RUN /rocker_scripts/add_ubuntugis.sh
-RUN /rocker_scripts/install_geospatial.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/add_ubuntugis.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_geospatial.sh
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_devel
+++ b/dockerfiles/Dockerfile_geospatial_devel
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_geospatial_devel
+++ b/dockerfiles/Dockerfile_geospatial_devel
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/verse:devel
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/verse:devel
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_geospatial.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_geospatial.sh
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.0-cuda10.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.0-cuda10.2-ubuntu18.04
@@ -1,15 +1,23 @@
+<<<<<<< HEAD
 FROM rocker/ml:4.0.0-cuda10.2-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/ml:4.0.0-cuda10.2-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_geospatial.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_verse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_geospatial.sh
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_latest
+++ b/dockerfiles/Dockerfile_ml-verse_latest
@@ -12,3 +12,4 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+

--- a/dockerfiles/Dockerfile_ml-verse_latest
+++ b/dockerfiles/Dockerfile_ml-verse_latest
@@ -1,10 +1,18 @@
+<<<<<<< HEAD
 FROM rocker/ml-verse:4.0.0-cuda10.2-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/ml-verse:4.0.0-cuda10.2-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.0-cuda10.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_ml_4.0.0-cuda10.2-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PANDOC_VERSION=default

--- a/dockerfiles/Dockerfile_ml_4.0.0-cuda10.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_ml_4.0.0-cuda10.2-ubuntu18.04
@@ -1,10 +1,18 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:4.0.0-cuda10.2-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:4.0.0-cuda10.2-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
@@ -14,10 +22,10 @@ ENV KERAS_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
-RUN /rocker_scripts/install_tidyverse.sh
-RUN /rocker_scripts/install_tensorflow.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_rstudio.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_pandoc.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tensorflow.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/Dockerfile_ml_latest
+++ b/dockerfiles/Dockerfile_ml_latest
@@ -12,3 +12,4 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+

--- a/dockerfiles/Dockerfile_ml_latest
+++ b/dockerfiles/Dockerfile_ml_latest
@@ -1,10 +1,18 @@
+<<<<<<< HEAD
 FROM rocker/ml:4.0.0-cuda10.2-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/ml:4.0.0-cuda10.2-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 

--- a/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM ubuntu:18.04
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,6 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV R_VERSION=3.6.3
 ENV TERM=xterm
@@ -15,7 +19,7 @@ ENV CRAN=https://mran.microsoft.com/snapshot/2020-04-24
 
 COPY scripts /rocker_scripts
 
-RUN /rocker_scripts/install_R.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_R.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_3.6.3-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV R_VERSION=3.6.3
 ENV TERM=xterm
 ENV LC_ALL=en_US.UTF-8

--- a/dockerfiles/Dockerfile_r-ver_4.0.0
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
 ENV LC_ALL=en_US.UTF-8

--- a/dockerfiles/Dockerfile_r-ver_4.0.0
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM ubuntu:20.04
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,6 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
@@ -15,7 +19,7 @@ ENV CRAN=https://cran.r-project.org
 
 COPY scripts /rocker_scripts
 
-RUN /rocker_scripts/install_R.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_R.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.2-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
 ENV LC_ALL=en_US.UTF-8

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.2-ubuntu18.04
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM nvidia/cuda:10.2-cudnn7-devel
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,6 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
@@ -22,9 +26,9 @@ ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts /rocker_scripts
 
-RUN /rocker_scripts/install_R.sh
-RUN /rocker_scripts/config_R_cuda.sh
-RUN /rocker_scripts/install_python.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_R.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/config_R_cuda.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_python.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
 ENV LC_ALL=en_US.UTF-8

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM ubuntu:18.04
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,6 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
@@ -15,7 +19,7 @@ ENV CRAN=https://cran.r-project.org
 
 COPY scripts /rocker_scripts
 
-RUN /rocker_scripts/install_R.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_R.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_r-ver_devel
+++ b/dockerfiles/Dockerfile_r-ver_devel
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV R_VERSION=devel
 ENV TERM=xterm
 ENV LC_ALL=en_US.UTF-8

--- a/dockerfiles/Dockerfile_r-ver_devel
+++ b/dockerfiles/Dockerfile_r-ver_devel
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM ubuntu:20.04
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,6 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV R_VERSION=devel
 ENV TERM=xterm
@@ -15,7 +19,7 @@ ENV CRAN=https://cran.r-project.org
 
 COPY scripts /rocker_scripts
 
-RUN /rocker_scripts/install_R.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_R.sh
 
 
 CMD R

--- a/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_3.6.3-ubuntu18.04
@@ -1,18 +1,26 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:3.6.3-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:3.6.3-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_rstudio.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_pandoc.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/Dockerfile_rstudio_4.0.0
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/Dockerfile_rstudio_4.0.0
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0
@@ -1,18 +1,26 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_rstudio.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_pandoc.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
@@ -1,18 +1,26 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:4.0.0-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:4.0.0-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_rstudio.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_pandoc.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/Dockerfile_rstudio_devel
+++ b/dockerfiles/Dockerfile_rstudio_devel
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/Dockerfile_rstudio_devel
+++ b/dockerfiles/Dockerfile_rstudio_devel
@@ -1,18 +1,26 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:devel
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:devel
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 
-RUN /rocker_scripts/install_rstudio.sh
-RUN /rocker_scripts/install_pandoc.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_rstudio.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_pandoc.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.0
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.0
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.0
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.0
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/shiny:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/shiny:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_shiny_3.6.3
+++ b/dockerfiles/Dockerfile_shiny_3.6.3
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 FROM rockerdev/r-ver:3.6.3
 
 LABEL org.label-schema.license="GPL-2.0" \
@@ -5,13 +6,16 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default
 
 
-RUN /rocker_scripts/install_shiny_server.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_shiny_server.sh
 
 EXPOSE 3838
 

--- a/dockerfiles/Dockerfile_shiny_3.6.3
+++ b/dockerfiles/Dockerfile_shiny_3.6.3
@@ -1,4 +1,4 @@
-FROM rocker/ml:4.0.0-cuda10.2-ubuntu18.04
+FROM rockerdev/r-ver:3.6.3
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -6,12 +6,16 @@ LABEL org.label-schema.license="GPL-2.0" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 
+ENV S6_VERSION=v1.21.7.0
+ENV SHINY_SERVER_VERSION=latest
+ENV PANDOC_VERSION=default
 
 
-RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_geospatial.sh
+RUN /rocker_scripts/install_shiny_server.sh
 
+EXPOSE 3838
 
+CMD /init
 
 
 

--- a/dockerfiles/Dockerfile_shiny_4.0.0
+++ b/dockerfiles/Dockerfile_shiny_4.0.0
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default

--- a/dockerfiles/Dockerfile_shiny_4.0.0
+++ b/dockerfiles/Dockerfile_shiny_4.0.0
@@ -1,17 +1,25 @@
+<<<<<<< HEAD
 FROM rocker/r-ver:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/r-ver:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default
 
 
-RUN /rocker_scripts/install_shiny_server.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_shiny_server.sh
 
 EXPOSE 3838
 

--- a/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_3.6.3-ubuntu18.04
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/rstudio:3.6.3-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/rstudio:3.6.3-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/rstudio:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/rstudio:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/rstudio:4.0.0-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/rstudio:4.0.0-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_devel
+++ b/dockerfiles/Dockerfile_tidyverse_devel
@@ -7,6 +7,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 
 
 
+
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_tidyverse_devel
+++ b/dockerfiles/Dockerfile_tidyverse_devel
@@ -1,14 +1,22 @@
+<<<<<<< HEAD
 FROM rocker/rstudio:devel
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/rstudio:devel
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 

--- a/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_3.6.3-ubuntu18.04
@@ -1,16 +1,24 @@
+<<<<<<< HEAD
 FROM rocker/tidyverse:3.6.3-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/tidyverse:3.6.3-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
-RUN /rocker_scripts/install_verse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_verse.sh
 
 
 

--- a/dockerfiles/Dockerfile_verse_4.0.0
+++ b/dockerfiles/Dockerfile_verse_4.0.0
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 

--- a/dockerfiles/Dockerfile_verse_4.0.0
+++ b/dockerfiles/Dockerfile_verse_4.0.0
@@ -1,16 +1,24 @@
+<<<<<<< HEAD
 FROM rocker/tidyverse:4.0.0
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/tidyverse:4.0.0
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
-RUN /rocker_scripts/install_verse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_verse.sh
 
 
 

--- a/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 

--- a/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
@@ -1,16 +1,24 @@
+<<<<<<< HEAD
 FROM rocker/tidyverse:4.0.0-ubuntu18.04
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/tidyverse:4.0.0-ubuntu18.04
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
-RUN /rocker_scripts/install_verse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_verse.sh
 
 
 

--- a/dockerfiles/Dockerfile_verse_devel
+++ b/dockerfiles/Dockerfile_verse_devel
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 

--- a/dockerfiles/Dockerfile_verse_devel
+++ b/dockerfiles/Dockerfile_verse_devel
@@ -1,16 +1,24 @@
+<<<<<<< HEAD
 FROM rocker/tidyverse:devel
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/tidyverse:devel
+>>>>>>> rebuild docker and compose files
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 
-RUN /rocker_scripts/install_verse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_verse.sh
 
 
 

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -1,11 +1,10 @@
 #!/usr/bin/env Rscript
 
 buildkit_cache = isTRUE(Sys.getenv("BUILDKIT_CACHE") == "1")
-cache_line = "--mount=type=cache,id=rocker_ccache,target=/.rocker_ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt"
+cache_line = "--mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt"
 syntax_line = "# syntax = docker/dockerfile:1.0-experimental"
 cache_arg = c("BUILDKIT_CACHE"="1",
               "R_MAKEVARS_SITE"="/rocker_scripts/Makevars.ccache",
-              "CCACHE_DIR"="/.rocker_ccache",
               "APT_CONFIG"="/rocker_scripts/apt-config")
 
 inherit_global <- function(image, global){

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -1,9 +1,10 @@
 #!/usr/bin/env Rscript
 
 buildkit_cache = isTRUE(Sys.getenv("BUILDKIT_CACHE") == "1")
-cache_line = "--mount=type=cache,target=/.rocker_ccache --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt"
+cache_line = "--mount=type=cache,id=rocker_ccache,target=/.rocker_ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt"
 syntax_line = "# syntax = docker/dockerfile:1.0-experimental"
-cache_arg = c("R_MAKEVARS_SITE"="/rocker_scripts/Makevars.ccache",
+cache_arg = c("BUILDKIT_CACHE"="1",
+              "R_MAKEVARS_SITE"="/rocker_scripts/Makevars.ccache",
               "CCACHE_DIR"="/.rocker_ccache",
               "APT_CONFIG"="/rocker_scripts/apt-config")
 

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -1,10 +1,11 @@
 #!/usr/bin/env Rscript
 
 buildkit_cache = isTRUE(Sys.getenv("BUILDKIT_CACHE") == "1")
-cache_line = "--mount=type=cache,target=/.rocker_ccache"
+cache_line = "--mount=type=cache,target=/.rocker_ccache --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt"
 syntax_line = "# syntax = docker/dockerfile:1.0-experimental"
 cache_arg = c("R_MAKEVARS_SITE"="/rocker_scripts/Makevars.ccache",
-              "CCACHE_DIR"="/.rocker_ccache")
+              "CCACHE_DIR"="/.rocker_ccache",
+              "APT_CONFIG"="/rocker_scripts/apt-config")
 
 inherit_global <- function(image, global){
   c(image, global[! names(global) %in% names(image) ])

--- a/partials/Dockerfile.start.partial
+++ b/partials/Dockerfile.start.partial
@@ -1,4 +1,9 @@
+<<<<<<< HEAD:partials/Dockerfile.start.partial
 FROM {{FROM_IMAGE}}
+=======
+# syntax = docker/dockerfile:1.0-experimental
+FROM rockerdev/shiny:3.6.3
+>>>>>>> rebuild docker and compose files:dockerfiles/Dockerfile_shiny-verse_3.6.3
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
@@ -7,10 +12,13 @@ LABEL org.label-schema.license="GPL-2.0" \
 <<<<<<< HEAD:partials/Dockerfile.start.partial
 =======
 
+ARG BUILDKIT_CACHE=1
+ARG R_MAKEVARS_SITE=/rocker_scripts/Makevars.ccache
+ARG APT_CONFIG=/rocker_scripts/apt-config
 
 
 
-RUN /rocker_scripts/install_tidyverse.sh
+RUN --mount=type=cache,id=rocker_ccache,target=/root/.ccache --mount=type=cache,id=rocker_cache_apt,target=/var/cache/apt --mount=type=cache,id=rocker_lib_apt,target=/var/lib/apt /rocker_scripts/install_tidyverse.sh
 
 
 

--- a/partials/Dockerfile.start.partial
+++ b/partials/Dockerfile.start.partial
@@ -4,3 +4,16 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
+<<<<<<< HEAD:partials/Dockerfile.start.partial
+=======
+
+
+
+
+RUN /rocker_scripts/install_tidyverse.sh
+
+
+
+
+
+>>>>>>> rebuild docker and compose files:dockerfiles/Dockerfile_shiny-verse_3.6.3

--- a/scripts/Makevars.ccache
+++ b/scripts/Makevars.ccache
@@ -1,0 +1,5 @@
+CCACHE=ccache
+CC=$(CCACHE) gcc$(VER)
+CXX=$(CCACHE) g++$(VER)
+CXX11=$(CCACHE) g++$(VER)
+CXX14=$(CCACHE) g++$(VER)

--- a/scripts/Makevars.ccache
+++ b/scripts/Makevars.ccache
@@ -1,5 +1,6 @@
 CCACHE=ccache
-CC=$(CCACHE) gcc$(VER)
-CXX=$(CCACHE) g++$(VER)
-CXX11=$(CCACHE) g++$(VER)
-CXX14=$(CCACHE) g++$(VER)
+CC=$(CCACHE) gcc
+CXX=$(CCACHE) g++
+CXX11=$(CCACHE) g++
+CXX14=$(CCACHE) g++
+CXX17=$(CCACHE) g++

--- a/scripts/apt-config
+++ b/scripts/apt-config
@@ -1,0 +1,6 @@
+Binary::apt::APT::Keep-Downloaded-Packages "true";
+Dir::Cache::srcpkgcache "srcpkgcache.bin";
+Dir::Cache::pkgcache "pkgcache.bin";
+DPkg::Post-Invoke "";
+APT::Update::Post-Invoke "";
+

--- a/scripts/install_R-devel.sh
+++ b/scripts/install_R-devel.sh
@@ -40,6 +40,9 @@ apt-get update \
 if [ "$BUILDKIT_CACHE" == "1" ] ; then
   apt-get install -y --no-install-recommends \
     ccache
+  /usr/sbin/update-ccache-symlinks
+  PATH="/usr/lib/ccache/:$PATH"  #gcc overwrite should only apply within this script
+  unset R_MAKEVARS_SITE        # don't want this ARG value if ccache gcc is in the path
 fi
 
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen

--- a/scripts/install_R-devel.sh
+++ b/scripts/install_R-devel.sh
@@ -111,12 +111,17 @@ chmod g+ws /usr/local/lib/R/site-library
 echo "R_LIBS_USER='/usr/local/lib/R/site-library'" >> /usr/local/lib/R/etc/Renviron
 echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
 
-  ## Use littler installation scripts
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
+
+## Use littler installation scripts
 Rscript -e "install.packages(c('littler', 'docopt'))"
 ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r
 ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r
 ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r
-
 
 ## Clean up from R source install
 cd /

--- a/scripts/install_R-devel.sh
+++ b/scripts/install_R-devel.sh
@@ -35,6 +35,12 @@ apt-get update \
     unzip \
     zip \
     zlib1g
+    
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
 
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen en_US.utf8
@@ -110,12 +116,6 @@ chmod g+ws /usr/local/lib/R/site-library
 ## Fix library path
 echo "R_LIBS_USER='/usr/local/lib/R/site-library'" >> /usr/local/lib/R/etc/Renviron
 echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
-
-# If using buildkit, install ccache
-if [ "$BUILDKIT_CACHE" == "1" ] ; then
-  apt-get install -y --no-install-recommends \
-    ccache
-fi
 
 ## Use littler installation scripts
 Rscript -e "install.packages(c('littler', 'docopt'))"

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -14,7 +14,6 @@ export DEBIAN_FRONTEND=noninteractive
 R_HOME=${R_HOME:-/usr/local/lib/R}
 
 
-
 ## ubuntu focal uses readline8, bionic uses readline7, wildcards don't work here
 ## consider libopenblas-openmp-dev instead on focal?
 ## Also note openmp is quite large
@@ -55,7 +54,11 @@ apt-get update \
 if [ "$BUILDKIT_CACHE" == "1" ] ; then
   apt-get install -y --no-install-recommends \
     ccache
+  /usr/sbin/update-ccache-symlinks
+  PATH="/usr/lib/ccache/:$PATH"  #gcc overwrite should only apply within this script
+  unset R_MAKEVARS_SITE        # don't want this ARG value if ccache gcc is in the path
 fi
+
 
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen en_US.utf8

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -99,7 +99,7 @@ else                                                                 \
     wget https://cran.r-project.org/src/base/R-3/R-${R_VERSION}.tar.gz || \
     wget https://cran.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz; \
 fi &&                                                                \
-    tar xzf R-${R_VERSION}.tar.gz &&   
+    tar xzf R-${R_VERSION}.tar.gz &&
 
 cd R-${R_VERSION}
 R_PAPERSIZE=letter \
@@ -137,12 +137,17 @@ chmod g+ws ${R_HOME}/site-library
 ## Fix library path
 echo "R_LIBS=\${R_LIBS-'${R_HOME}/site-library:${R_HOME}/library'}" >> ${R_HOME}/etc/Renviron
 
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
+
 ## Use littler installation scripts
 Rscript -e "install.packages(c('littler', 'docopt'))"
 ln -s ${R_HOME}/site-library/littler/examples/install2.r /usr/local/bin/install2.r
 ln -s ${R_HOME}/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r
 ln -s ${R_HOME}/site-library/littler/bin/r /usr/local/bin/r
-
 
 ## Clean up from R source install
 cd /

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -51,6 +51,12 @@ apt-get update \
     zip \
     zlib1g
 
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
+
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen en_US.utf8
 /usr/sbin/update-locale LANG=en_US.UTF-8
@@ -137,12 +143,6 @@ chmod g+ws ${R_HOME}/site-library
 ## Fix library path
 echo "R_LIBS=\${R_LIBS-'${R_HOME}/site-library:${R_HOME}/library'}" >> ${R_HOME}/etc/Renviron
 
-# If using buildkit, install ccache
-if [ "$BUILDKIT_CACHE" == "1" ] ; then
-  apt-get install -y --no-install-recommends \
-    ccache
-fi
-
 ## Use littler installation scripts
 Rscript -e "install.packages(c('littler', 'docopt'))"
 ln -s ${R_HOME}/site-library/littler/examples/install2.r /usr/local/bin/install2.r
@@ -158,5 +158,6 @@ apt-get remove --purge -y $BUILDDEPS
 apt-get autoremove -y
 apt-get autoclean -y
 rm -rf /var/lib/apt/lists/*
+
 
 

--- a/scripts/install_R_ppa.sh
+++ b/scripts/install_R_ppa.sh
@@ -27,6 +27,12 @@ apt-get -y install --no-install-recommends \
       dirmngr \
       gpg \
       gpg-agent
+      
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
 
 echo "deb http://cloud.r-project.org/bin/linux/ubuntu ${UBUNTU_VERSION}-${CRAN_LINUX_VERSION}/" >> /etc/apt/sources.list
 
@@ -49,12 +55,6 @@ rm -rf /var/lib/apt/lists/*
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen en_US.utf8
 /usr/sbin/update-locale LANG=${LANG}
-
-# If using buildkit, install ccache
-if [ "$BUILDKIT_CACHE" == "1" ] ; then
-  apt-get install -y --no-install-recommends \
-    ccache
-fi
 
 Rscript -e "install.packages(c('littler', 'docopt'))"
 

--- a/scripts/install_R_ppa.sh
+++ b/scripts/install_R_ppa.sh
@@ -41,14 +41,20 @@ apt-get update && apt-get -y install --no-install-recommends r-base-dev=${R_VERS
 
 rm -rf /var/lib/apt/lists/*
 
-## Add PPAs: NOTE this will mean that installing binary R packages won't be version stable.  
-## 
-## These are required at least for bionic-based images since 3.4 r binaries are 
+## Add PPAs: NOTE this will mean that installing binary R packages won't be version stable.
+##
+## These are required at least for bionic-based images since 3.4 r binaries are
 
 
 echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen en_US.utf8
 /usr/sbin/update-locale LANG=${LANG}
+
+# If using buildkit, install ccache
+if [ "$BUILDKIT_CACHE" == "1" ] ; then
+  apt-get install -y --no-install-recommends \
+    ccache
+fi
 
 Rscript -e "install.packages(c('littler', 'docopt'))"
 

--- a/scripts/install_R_ppa.sh
+++ b/scripts/install_R_ppa.sh
@@ -32,6 +32,9 @@ apt-get -y install --no-install-recommends \
 if [ "$BUILDKIT_CACHE" == "1" ] ; then
   apt-get install -y --no-install-recommends \
     ccache
+  /usr/sbin/update-ccache-symlinks
+  PATH="/usr/lib/ccache/:$PATH"  #gcc overwrite should only apply within this script
+  unset R_MAKEVARS_SITE        # don't want this ARG value if ccache gcc is in the path
 fi
 
 echo "deb http://cloud.r-project.org/bin/linux/ubuntu ${UBUNTU_VERSION}-${CRAN_LINUX_VERSION}/" >> /etc/apt/sources.list


### PR DESCRIPTION
This is a first pass on user Docker Buildkit and ccache to speed up builds.  It requires a recent docker install with experimental features turned on. Still checking that it all works

Running `make BUILDKIT_CACHE=1 target` does the following:
- Creates dockerfiles that have 
   -  headers to trigger extended features
   - `RUN` statements specifying cacheing
    - Added `ARG` statements specifying CCACHE location and to use a custom `Makevars.ccache` for package installation that uses ccache
  - Installs ccache in the `install_R*.sh` 

Some things to consider/improve
  - We could install ccache by default (makes it easier for people to use it later)
  - `apt` packages can be cached, see [here](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#example-cache-apt-packages), I just want to understand how this interacts with our scripts and cleanup
 - The `Makevars` approach could be how to parallel compiles.  `Ncpu` installs multiple _packages_ in parallel.  One can compile C code in parallel within individual packages like this:

    ```
    NPROC=$(shell nproc)
    NPROC_MIN=$(shell $(($NPROC>4?4:$NPROC)))
    MAKEFLAGS+="-j $(NPROC_MIN)"
    ```  

    But we'd want to think about nesting parallelism of stacks/images/packages/compiled files.