### PR TITLE
Fixup install_shiny_server script and dependency scripts

### DIFF
--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -8,7 +8,7 @@ PANDOC_VERSION=${1:-${PANDOC_VERSION:-default}}
 
 apt-get update && apt-get -y install wget
 
-if [-x "$(command -v pandoc)" ]; then
+if [ -x "$(command -v pandoc)" ]; then
   INSTALLED_PANDOC=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
 fi
 
@@ -17,8 +17,8 @@ if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
   if [ -f "/usr/lib/rstudio-server/bin/pandoc/pandoc" ] &&
       { [ "$PANDOC_VERSION" = "$(/usr/lib/rstudio-server/bin/pandoc/pandoc --version | head -n 1 | grep -oP '[\d\.]+$')" ] ||
         [ "$PANDOC_VERSION" = "default" ]; }; then
-    ln -s /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin
-    ln -s /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin
+    ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin
+    ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin
   else
     if [ "$PANDOC_VERSION" = "default" ]; then
       PANDOC_DL_URL=$(wget -qO- https://api.github.com/repos/jgm/pandoc/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*amd64\.deb")
@@ -29,13 +29,15 @@ if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
     dpkg -i pandoc-amd64.deb
     rm pandoc-amd64.deb
   fi
-  
+
   ## Symlink pandoc & standard pandoc templates for use system-wide
   PANDOC_TEMPLATES_VERSION=`pandoc -v | grep -oP "(?<=pandoc\s)[0-9\.]+$"`
   wget https://github.com/jgm/pandoc-templates/archive/${PANDOC_TEMPLATES_VERSION}.tar.gz -O pandoc-templates.tar.gz
+  rm -fr /opt/pandoc/templates
   mkdir -p /opt/pandoc/templates
   tar xvf pandoc-templates.tar.gz
-  cp -r pandoc-templates*/* /opt/pandoc/templates && rm -rf pandoc-templates* 
+  cp -r pandoc-templates*/* /opt/pandoc/templates && rm -rf pandoc-templates*
+  rm -fr /root/.pandoc
   mkdir /root/.pandoc && ln -s /opt/pandoc/templates /root/.pandoc/templates
-  
+
 fi

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -13,11 +13,10 @@ if [ -f "/rocker_scripts/.s6_version" ] && [ "$S6_VERSION" = "$(cat /rocker_scri
   echo "S6 already installed"
 else
   wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz
-  
-  ## need the modified double tar now, see https://github.com/just-containers/s6-overlay/issues/288 
+
+  ## need the modified double tar now, see https://github.com/just-containers/s6-overlay/issues/288
   tar hzxf /tmp/s6-overlay-amd64.tar.gz -C / --exclude=usr/bin/execlineb
   tar hzxf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin/execlineb && $_clean
 
-  echo "S6_VERSION" > /rocker_scripts/.s6_version
+  echo "$S6_VERSION" > /rocker_scripts/.s6_version
 fi
-

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -30,33 +30,29 @@ rm ss-latest.deb
 # Get R packages
 install2.r --error --skipinstalled shiny rmarkdown
 
-# Set up directories and presmissions
+# Set up directories and permissions
 if [ -x "$(command -v rstudio-server)" ]; then
   DEFAULT_USER=${DEFAULT_USER:-rstudio}
   adduser ${DEFAULT_USER} shiny
 fi
 
-cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ 
+cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/
 chown shiny:shiny /var/lib/shiny-server
 mkdir -p /var/log/shiny-server
-chown shiny.shiny /var/log/shiny-server
+chown shiny:shiny /var/log/shiny-server
 
 # create init scripts
 mkdir -p /etc/services.d/shiny-server
-echo echo "#!/usr/bin/with-contenv bash \
-          \n## load /etc/environment vars first: \
-          \n for line in $( cat /etc/environment ) ; do export $line > /dev/null; done \
-          \nif [ \"\$APPLICATION_LOGS_TO_STDOUT\" != \"false\" ]; then \
-          \n    exec xtail /var/log/shiny-server/ & \
-          \nfi \
-          \nexec shiny-server > 2>&1 \
-          \n" > /etc/services.d/shiny-server/run
+cat > /etc/services.d/shiny-server/run << 'EOF'
+#!/usr/bin/with-contenv bash
+## load /etc/environment vars first:
+for line in $( cat /etc/environment ) ; do export $line > /dev/null; done
+if [ "$APPLICATION_LOGS_TO_STDOUT" != "false" ]; then
+    exec xtail /var/log/shiny-server/ &
+fi
+exec shiny-server 2>&1
+EOF
 chmod +x /etc/services.d/shiny-server/run
-      
+
 # Clean up
 rm -rf /var/lib/apt/lists/*
-
-
-
-
-


### PR DESCRIPTION
Hello, and thank you for developing and maintaining the `rocker` R images.  :)

Past versions of the `rocker/rstudio` image had a `/etc/cont-init.d/add` script that made it easy to automatically install and configure Shiny Server. I recently noticed that this script has been replaced by `/rocker_scripts/install_shiny_server.sh`, so I tried running it.

However, the dependency script `install_pandoc.sh` failed due to assumptions that the script would only be one run once. I've made minimal changes to allow the script to be re-run and trimmed whitespace.

Also, I noticed a bug in `install_s6init.sh` where the string literal `S6_VERSION` was being written to `/rocker_scripts/.s6_version` instead of the value of the `S6_VERSION` variable. I've fixed that as well, and also trimmed whitespace.

I also addressed several issues with `install_shiny_server.sh`, including fixing `shiny.shiny` → `shiny:shiny` in a `chown` command, replacing a multi-line `echo` command with some unexpected substitutions with `cat`-ing a heredoc, and removing a bare stdout redirection operator that had no destination specified. Also, I trimmed whitespace. :)

After making these changes, I was able to get Shiny Server working within `rocker/rstudio`.