### PR TITLE
Fix HTTPUserAgent in install_R.sh

### DIFF
--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -130,9 +130,9 @@ make clean
 echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >> ${R_HOME}/etc/Rprofile.site
 
 ## Set HTTPUserAgent for RSPM (https://github.com/rocker-org/rocker/issues/400)
-echo  "options(HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(), 
+echo  'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), 
                  paste(getRversion(), R.version$platform, 
-                       R.version$arch, R.version$os)))" >> ${R_HOME}/etc/Rprofile.site
+                       R.version$arch, R.version$os)))' >> ${R_HOME}/etc/Rprofile.site
 
 
 ## Add a library directory (for user-installed packages)


### PR DESCRIPTION
Lets compare output:
```bash
root@56e309577550:/# echo  "options(HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(), 
>                  paste(getRversion(), R.version$platform, 
>                        R.version$arch, R.version$os)))"
options(HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(), 
                 paste(getRversion(), R.version, 
                       R.version, R.version)))
root@56e309577550:/# echo  'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), 
>                  paste(getRversion(), R.version$platform, 
>                        R.version$arch, R.version$os)))'
options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), 
                 paste(getRversion(), R.version$platform, 
                       R.version$arch, R.version$os)))
```