### PR TITLE
Add r-ver:4.0.2-ubuntu18.04 and rstudio:4.0.2-ubuntu:18.04

### DIFF
--- a/dockerfiles/Dockerfile_r-ver_4.0.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.2-ubuntu18.04
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV R_VERSION=4.0.2
+ENV TERM=xterm
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV R_HOME=/usr/local/lib/R
+ENV CRAN=https://packagemanager.rstudio.com/all/__linux__/bionic/latest
+ENV TZ=UTC
+
+COPY scripts /rocker_scripts
+
+RUN /rocker_scripts/install_R.sh
+
+
+CMD ["R"]
+
+
+

--- a/dockerfiles/Dockerfile_rstudio_4.0.2-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_4.0.2-ubuntu18.04
@@ -1,0 +1,21 @@
+FROM rocker/r-ver:4.0.2-ubuntu18.04
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
+      org.label-schema.vendor="Rocker Project" \
+      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV S6_VERSION=v1.21.7.0
+ENV RSTUDIO_VERSION=latest
+ENV PATH=/usr/lib/rstudio-server/bin:$PATH
+
+
+RUN /rocker_scripts/install_rstudio.sh
+RUN /rocker_scripts/install_pandoc.sh
+
+EXPOSE 8787
+
+CMD ["/init"]
+
+
+

--- a/stacks/core-4.0.2-ubuntu18.04.json
+++ b/stacks/core-4.0.2-ubuntu18.04.json
@@ -1,0 +1,54 @@
+{
+  "ordered": true,
+  "TAG": "4.0.2-ubuntu18.04",
+  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+
+  "stack": [
+  {
+    "IMAGE": "r-ver",
+    "FROM": "ubuntu:18.04",
+    "ENV": {
+      "R_VERSION": "4.0.2",
+      "TERM": "xterm",
+      "LC_ALL": "en_US.UTF-8",
+      "LANG": "en_US.UTF-8",
+      "R_HOME": "/usr/local/lib/R",
+      "CRAN": "https://packagemanager.rstudio.com/all/__linux__/bionic/latest",
+      "TZ": "UTC"
+    },
+    "COPY": "scripts /rocker_scripts",
+    "RUN": "/rocker_scripts/install_R.sh",
+    "CMD": "[\"R\"]"
+  },
+  {
+    "IMAGE": "rstudio",
+    "FROM": "rocker/r-ver:4.0.2-ubuntu18.04",
+    "ENV": {
+      "S6_VERSION": "v1.21.7.0",
+      "RSTUDIO_VERSION": "latest",
+      "PATH": "/usr/lib/rstudio-server/bin:$PATH"
+    },
+    "RUN": ["/rocker_scripts/install_rstudio.sh", "/rocker_scripts/install_pandoc.sh"],
+    "CMD": "[\"/init\"]",
+    "EXPOSE": 8787
+  },
+  {
+    "IMAGE": "tidyverse",
+    "FROM": "rocker/rstudio:4.0.2-ubuntu18.04",
+    "RUN": "/rocker_scripts/install_tidyverse.sh"
+  },
+  {
+    "IMAGE": "verse",
+    "FROM": "rocker/tidyverse:4.0.2-ubuntu18.04",
+    "ENV": {
+      "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet", 
+      "PATH": "/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH"
+    },
+    "RUN": "/rocker_scripts/install_verse.sh"
+  }
+  ]
+}
+
+
+
+


### PR DESCRIPTION
These images are used by the bioconductor images and it would be really
helpful to the whole Bioconductor community if they are included in the
rocker-versioned2 repository

This addresses #69 