### PR TITLE
Initial Kubeflow support

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -88,6 +88,15 @@ echo "lock-type=advisory" > /etc/rstudio/file-locks
 cp /etc/rstudio/rserver.conf /etc/rstudio/disable_auth_rserver.conf
 echo "auth-none=1" >> /etc/rstudio/disable_auth_rserver.conf
 
+## Prepare optional configuration file to disable authentication
+## and set variables for Kubeflow
+## To set variables, `kubeflow_rserver.conf` script
+## will just need to be overwrite /etc/rstudio/rserver.conf. 
+## This is triggered when NB_PREFIX is set by Kubeflow
+cp /etc/rstudio/rserver.conf /etc/rstudio/kubeflow_rserver.conf
+echo "auth-none=1" >> /etc/rstudio/kubeflow_rserver.conf
+echo "www-port=8888" >> /etc/rstudio/kubeflow_rserver.conf
+
 ## Set up RStudio init scripts
 mkdir -p /etc/services.d/rstudio
 echo '#!/usr/bin/with-contenv bash

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -23,6 +23,15 @@ then
 fi
 
 
+if [[ ${NB_PREFIX,,} != "" ]]
+
+then
+	echo "www-root-path=${NB_PREFIX}" >> /etc/rstudio/kubeflow_rserver.conf
+  mv /etc/rstudio/kubeflow_rserver.conf /etc/rstudio/rserver.conf
+	echo "USER=$USER" >> /etc/environment
+fi
+
+
 
 if grep --quiet "auth-none=1" /etc/rstudio/rserver.conf
 then


### PR DESCRIPTION
If the environment variable `NB_PREFIX` is used, it is assumed rstudio is from kubeflow and thus userconf.sh will set `www-root-path` to
 `$NB_PREFIX`, set `www-port=8888` and it will disable auth. `RSTUDIO_VERSION=daily` or `RSTUDIO_VERSION=preview` need to be used (daily not working, preview not tested). On daily, the 404 page loads saying:
```
RSudio Server
The requested page was not found.
Please contact your system administrator for assistance, or click here to go back.
```
This was tested with a Dockerfile that exposes port 8888 rather than 8787 (Kubeflow expects 8888).