### PR TITLE
Standardise on using bash in scripts

### DIFF
--- a/scripts/bh-proj.sh
+++ b/scripts/bh-proj.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 mkdir proj

--- a/scripts/experimental/install_rl.sh
+++ b/scripts/experimental/install_rl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 python -m venv /opt/venv/rl
@@ -9,5 +9,3 @@ pip install gym tensorflow keras keras-rl
 
 chown -R :staff /opt/venv/rl
 chmod g+rx /opt/venv/rl
-
-

--- a/scripts/install_cuda-10.1.sh
+++ b/scripts/install_cuda-10.1.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 apt-get update && apt-get install -y --no-install-recommends \
 gnupg2 curl ca-certificates && \

--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 # always set this for scripts but don't declare as ENV..
@@ -37,12 +36,12 @@ apt-get update -qq \
 ## permissionless PAT for builds
 UBUNTU_VERSION=${UBUNTU_VERSION:-`lsb_release -sc`}
 
-if [ ${UBUNTU_VERSION} == "bionic" ]; then 
+if [ ${UBUNTU_VERSION} == "bionic" ]; then
   R -e "Sys.setenv(GITHUB_PAT='0e7777db4b3bb48acb542b8912a989b8047f6351'); remotes::install_github('r-spatial/lwgeom')"
 fi
 
 
-## Somehow foreign is messed up on CRAN between 2020-04-25 -- 2020-05-0?  
+## Somehow foreign is messed up on CRAN between 2020-04-25 -- 2020-05-0?
 ##install2.r --error --skipinstalled --repo https://mran.microsoft.com/snapshot/2020-04-24 foreign
 
 install2.r --error --skipinstalled \
@@ -77,7 +76,7 @@ install2.r --error --skipinstalled \
 
 R -e "BiocManager::install('rhdf5')"
 
-## install wgrib2 for NOAA's NOMADS / rNOMADS forecast files 
+## install wgrib2 for NOAA's NOMADS / rNOMADS forecast files
 /rocker_scripts/install_wgrib2.sh
 
 rm -r /tmp/downloaded_packages

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Note that 'default' pandoc version means the version bundled with RStudio

--- a/scripts/install_proj.sh
+++ b/scripts/install_proj.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 git clone https://github.com/OSGeo/PROJ

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 ### Sets up S6 supervisor.

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 SHINY_SERVER_VERSION=${1:-${SHINY_SERVER_VERSION:-latest}}

--- a/scripts/install_tensorflow.sh
+++ b/scripts/install_tensorflow.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 TENSORFLOW_VERSION=${1:-${TENSORFLOW_VERSION:-default}}

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo 'selected_scheme scheme-infraonly
 TEXDIR /usr/local/texlive
 TEXMFCONFIG /opt/texlive/texmf-config

--- a/scripts/pam-helper.sh
+++ b/scripts/pam-helper.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -o nounset
 
 ## Enforces the custom password specified in the PASSWORD environment variable
 ## The accepted RStudio username is the same as the USER environment variable (i.e., local user name).
 
-set -o nounset
 
 IFS='' read -r password
 


### PR DESCRIPTION
We only use S6's with-contenv/bash where we need the system variables at
runtime.

This makes a little less surprising when you suddenly don't have access to some of the bash-isms in scripts.
