### PR TITLE
Configure RStudio Server logging

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -69,7 +69,7 @@ rm rstudio-server-*-amd64.deb
 
 ## RStudio wants an /etc/R, will populate from $R_HOME/etc
 mkdir -p /etc/R
-echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
+echo "PATH=${PATH}" >> "${R_HOME}/etc/Renviron"
 
 ## Make RStudio compatible with case when R is built from source
 ## (and thus is at /usr/local/bin/R), because RStudio doesn't obey
@@ -88,6 +88,7 @@ echo "auth-none=1" >> /etc/rstudio/disable_auth_rserver.conf
 
 ## Set up RStudio init scripts
 mkdir -p /etc/services.d/rstudio
+# shellcheck disable=SC2016
 echo '#!/usr/bin/with-contenv bash
 ## load /etc/environment vars first:
 for line in $( cat /etc/environment ) ; do export $line > /dev/null; done
@@ -120,12 +121,15 @@ cp /rocker_scripts/userconf.sh /etc/cont-init.d/userconf
 cp /rocker_scripts/pam-helper.sh /usr/lib/rstudio-server/bin/pam-helper
 
 ## Rocker's default RStudio settings, for better reproducibility
+
+USER_SETTINGS='alwaysSaveHistory="0"
+loadRData="0"
+saveAction="0"
+'
+
 mkdir -p /home/rstudio/.rstudio/monitored/user-settings \
-  && echo 'alwaysSaveHistory="0" \
-          \nloadRData="0" \
-          \nsaveAction="0"' \
+  && printf "%s" "$USER_SETTINGS" \
           > /home/rstudio/.rstudio/monitored/user-settings/user-settings \
   && chown -R rstudio:rstudio /home/rstudio/.rstudio
 
-##
 git config --system credential.helper 'cache --timeout=3600'

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -57,11 +57,11 @@ fi
 RSTUDIO_URL="https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
 
 if [ "$UBUNTU_VERSION" = "xenial" ]; then
-  wget $RSTUDIO_URL || \
-  wget `echo $RSTUDIO_URL | sed 's/server-/server-xenial-/'` || \
-  wget `echo $RSTUDIO_URL | sed 's/xenial/trusty/'`
+  wget "${RSTUDIO_URL}" || \
+  wget "${RSTUDIO_URL//server-/server-xenial-/}" || \
+  wget "${RSTUDIO_URL//xenial/trusty/}"
 else
-  wget $RSTUDIO_URL
+  wget "${RSTUDIO_URL}"
 fi
 
 dpkg -i rstudio-server-*-amd64.deb

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -104,6 +104,14 @@ if [ ! -z "$CUDA_HOME" ]; then
   echo "rsession-ld-library-path=$LD_LIBRARY_PATH" >> /etc/rstudio/rserver.conf
 fi
 
+# Log to stderr
+LOGGING="[*]
+log-level=warn
+logger-type=stderr
+"
+
+printf "%s" "$LOGGING" > /etc/rstudio/logging.conf
+
 # set up default user
 /rocker_scripts/default_user.sh
 

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -41,11 +41,11 @@ if [ -z "$1" ];
 fi
 
 if [ -z "$RSTUDIO_VERSION_ARG" ] || [ "$RSTUDIO_VERSION_ARG" = "latest" ]; then
-    DOWNLOAD_VERSION=`wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1`
+    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "preview" ]; then
-    DOWNLOAD_VERSION=`wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1`
+    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "daily" ]; then
-    DOWNLOAD_VERSION=`wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1`
+    DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1)
 else
     DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG}
 fi
@@ -74,7 +74,7 @@ echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 ## Make RStudio compatible with case when R is built from source
 ## (and thus is at /usr/local/bin/R), because RStudio doesn't obey
 ## path if a user apt-get installs a package
-R_BIN=`which R`
+R_BIN=$(which R)
 echo "rsession-which-r=${R_BIN}" > /etc/rstudio/rserver.conf
 ## use more robust file locking to avoid errors when using shared volumes:
 echo "lock-type=advisory" > /etc/rstudio/file-locks


### PR DESCRIPTION
Resolves #115

- Configures RStudio logging via `/etc/rstudio/logging.conf`
- Stop using legacy back tick notation for bash sub-shell
- Use Bash string replace instead of echo & sed
-  Quote variables wherever possible
