### PR TITLE
Remove duplicate COPY section form r-ver-cuda

### DIFF
--- a/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.1-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.1-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.2-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.2-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.3-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.3-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.3-cuda11.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.3-cuda11.1
@@ -19,7 +19,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_MINICONDA_ENABLED=FALSE
 ENV PATH=${PYTHON_VENV_PATH}/bin:${CUDA_HOME}/bin:/usr/local/nviida/bin:${PATH}:/usr/local/texlive/bin/x86_64-linux
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-11.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.4-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.4-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.4-cuda11.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.4-cuda11.1
@@ -19,7 +19,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_MINICONDA_ENABLED=FALSE
 ENV PATH=${PYTHON_VENV_PATH}/bin:${CUDA_HOME}/bin:/usr/local/nviida/bin:${PATH}:/usr/local/texlive/bin/x86_64-linux
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-11.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/dockerfiles/Dockerfile_r-ver_devel-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_devel-cuda10.1
@@ -18,7 +18,6 @@ ENV PYTHON_VENV_PATH=/opt/venv/reticulate
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 
-COPY scripts/ /rocker_scripts/
 
 RUN /rocker_scripts/install_cuda-10.1.sh
 RUN /rocker_scripts/config_R_cuda.sh

--- a/stacks/ml-cuda10.1-4.0.0.json
+++ b/stacks/ml-cuda10.1-4.0.0.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-4.0.1.json
+++ b/stacks/ml-cuda10.1-4.0.1.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-4.0.2.json
+++ b/stacks/ml-cuda10.1-4.0.2.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-4.0.3.json
+++ b/stacks/ml-cuda10.1-4.0.3.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-4.0.4.json
+++ b/stacks/ml-cuda10.1-4.0.4.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-4.0.5.json
+++ b/stacks/ml-cuda10.1-4.0.5.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:$PATH:${CUDA_HOME}/bin:/usr/local/texlive/bin/x86_64-linux"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda10.1-devel.json
+++ b/stacks/ml-cuda10.1-devel.json
@@ -22,7 +22,6 @@
       "RETICULATE_AUTOCONFIGURE": "0",
       "PATH": "${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-10.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda11.1-4.0.3.json
+++ b/stacks/ml-cuda11.1-4.0.3.json
@@ -23,7 +23,6 @@
       "RETICULATE_MINICONDA_ENABLED": "FALSE",
       "PATH": "${PYTHON_VENV_PATH}/bin:${CUDA_HOME}/bin:/usr/local/nviida/bin:${PATH}:/usr/local/texlive/bin/x86_64-linux"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-11.1.sh",
       "/rocker_scripts/config_R_cuda.sh",

--- a/stacks/ml-cuda11.1-4.0.4.json
+++ b/stacks/ml-cuda11.1-4.0.4.json
@@ -23,7 +23,6 @@
       "RETICULATE_MINICONDA_ENABLED": "FALSE",
       "PATH": "${PYTHON_VENV_PATH}/bin:${CUDA_HOME}/bin:/usr/local/nviida/bin:${PATH}:/usr/local/texlive/bin/x86_64-linux"
      },
-    "COPY": "scripts/ /rocker_scripts/",
     "RUN": [
       "/rocker_scripts/install_cuda-11.1.sh",
       "/rocker_scripts/config_R_cuda.sh",


### PR DESCRIPTION
`/rocker_scripts` already exist because these images are based on `rocker/r-ver`.
I don't think we need to copy scripts again in the Dockerfiles.