### PR TITLE
Delete cache files

### DIFF
--- a/scripts/add_ubuntugis.sh
+++ b/scripts/add_ubuntugis.sh
@@ -14,3 +14,6 @@ apt-get update \
   wget \
   ca-certificates \
   && add-apt-repository --enable-source --yes "ppa:ubuntugis/ubuntugis-$UBUNTUGIS_VERSION"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/dev_osgeo.sh
+++ b/scripts/dev_osgeo.sh
@@ -127,3 +127,6 @@ R CMD INSTALL sf
 R CMD INSTALL lwgeom
 R CMD build --no-build-vignettes --no-manual stars
 R CMD INSTALL stars
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -78,4 +78,6 @@ R -e "BiocManager::install('rhdf5')"
 ## install wgrib2 for NOAA's NOMADS / rNOMADS forecast files
 /rocker_scripts/install_wgrib2.sh
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
 rm -r /tmp/downloaded_packages

--- a/scripts/install_nvtop.sh
+++ b/scripts/install_nvtop.sh
@@ -7,3 +7,6 @@ mkdir -p nvtop/build && cd nvtop/build
 cmake .. -DNVML_RETRIEVE_HEADER_ONLINE=True
 make
 make install
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -40,3 +40,6 @@ if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
   rm -fr /root/.pandoc
   mkdir /root/.pandoc && ln -s /opt/pandoc/templates /root/.pandoc/templates
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_pyenv.sh
+++ b/scripts/install_pyenv.sh
@@ -9,7 +9,7 @@
 set -e
 
 apt-get update && apt-get -y install curl python3-pip
-pip install --upgrade --ignore-installed pipenv 
+python3 -m pip --no-cache-dir install --upgrade --ignore-installed pipenv
 
 
 # consider a version-stable alternative for the installer?
@@ -22,6 +22,5 @@ echo 'PATH="/opt/pyenv/bin:~/.local/bin:$PATH"' >> /etc/bash.bashrc
 echo 'eval "$(pyenv init -)"' >>  /etc/bash.bashrc
 echo 'eval "$(pyenv virtualenv-init -)"' >> /etc/bash.bashrc
 
-
-
-
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -52,3 +52,7 @@ fi
 chown -R :staff ${WORKON_HOME}
 chmod g+wx ${WORKON_HOME}
 chown :staff ${PYTHON_VENV_PATH}
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/downloaded_packages

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -20,3 +20,6 @@ else
 
   echo "$S6_VERSION" > /rocker_scripts/.s6_version
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -56,3 +56,4 @@ chmod +x /etc/services.d/shiny-server/run
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/downloaded_packages

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -12,3 +12,6 @@ cd grib2
 ## really someone needs to learn proper packaging conventions, but whatever
 CC=gcc FC=gfortran make
 ln -s /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
+
+# Clean up
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Some installation scripts does not delete the cache files, so leaving the cache files in the images.

For example, `rocker/rstudio` has apt cache files from `install_s6init.sh` `install_pandoc.sh`.

```bash
$ docker run --rm -it rocker/rstudio ls -lh /var/lib/apt/lists
total 27M
```

`rocker/shiny` has R package cache files from `install_shiny_server.sh`.

```bash
$ docker run --rm -it rocker/shiny ls -lh /tmp/downloaded_packages
total 49M
```

I think it's a good idea to bring Clean up section to the end of each script, like `install_shiny_server.sh`, to make the contents of the script easier to understand.