### PR TITLE
add pagedown package and Chrome in verse

### DIFF
--- a/scripts/install_chrome.sh
+++ b/scripts/install_chrome.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# install Google Chrome instead of Chromium because Chromium is only available as a Snap package
+curl -LO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
+apt-get update && apt-get install -y --no-install-recommends \
+        ./google-chrome-stable_current_amd64.deb
+
+rm google-chrome-stable_current_amd64.deb

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -70,9 +70,12 @@ wget "https://travis-bin.yihui.name/texlive-local.deb" \
 ## Install texlive
 /rocker_scripts/install_texlive.sh
 
+## Install Chrome for pagedown support
+/rocker_scripts/install_chrome.sh
+
 install2.r --error -r $CRAN --skipinstalled tinytex
 install2.r --error --deps TRUE -r $CRAN --skipinstalled \
-    blogdown bookdown rticles rmdshower rJava xaringan
+    blogdown bookdown pagedown rticles rmdshower rJava xaringan
 
 rm -rf /tmp/downloaded_packages
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request proposes: 
- to install the [`pagedown`](https://cran.r-project.org/package=pagedown) package in `rocker/verse`
- to add an install script for Chrome which is required to build PDF files using `pagedown`

Chrome is installed through an independent script because I think it could be usefull for other purposes: for instance, the [`ẁebshot`](https://cran.r-project.org/package=webshot) package will be superseded by the [`webshot2`](https://github.com/rstudio/webshot2) package which requires Chrome.

This pull request does not propose to install Chromium for the following reason: since Ubuntu 19.04, Chromium is only available as a Snap package and `snapd` does not work in containers. There is no debian package for Chromium. IMHO, the most simple alternative is to use Google Chrome.