### PR TITLE
Replace labels to OCI pre-defined annotations 

### DIFF
--- a/dockerfiles/Dockerfile_binder_4.0.0
+++ b/dockerfiles/Dockerfile_binder_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_4.0.1
+++ b/dockerfiles/Dockerfile_binder_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_4.0.2
+++ b/dockerfiles/Dockerfile_binder_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_4.0.3
+++ b/dockerfiles/Dockerfile_binder_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_4.0.4
+++ b/dockerfiles/Dockerfile_binder_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_4.0.5
+++ b/dockerfiles/Dockerfile_binder_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_binder_devel
+++ b/dockerfiles/Dockerfile_binder_devel
@@ -1,9 +1,9 @@
 FROM rocker/geospatial:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV NB_USER=rstudio
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.0-ubuntu18.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntugis
+++ b/dockerfiles/Dockerfile_geospatial_4.0.0-ubuntugis
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.1
+++ b/dockerfiles/Dockerfile_geospatial_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.1-ubuntugis
+++ b/dockerfiles/Dockerfile_geospatial_4.0.1-ubuntugis
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.2
+++ b/dockerfiles/Dockerfile_geospatial_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.2-ubuntugis
+++ b/dockerfiles/Dockerfile_geospatial_4.0.2-ubuntugis
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.3
+++ b/dockerfiles/Dockerfile_geospatial_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.3-ubuntugis
+++ b/dockerfiles/Dockerfile_geospatial_4.0.3-ubuntugis
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.4
+++ b/dockerfiles/Dockerfile_geospatial_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.4-daily
+++ b/dockerfiles/Dockerfile_geospatial_4.0.4-daily
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.4-daily
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_4.0.5
+++ b/dockerfiles/Dockerfile_geospatial_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_dev-osgeo
+++ b/dockerfiles/Dockerfile_geospatial_dev-osgeo
@@ -1,9 +1,9 @@
 FROM rocker/verse:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV PROJ_VERSION=7.2.0
 ENV GDAL_VERSION=3.2.0

--- a/dockerfiles/Dockerfile_geospatial_devel
+++ b/dockerfiles/Dockerfile_geospatial_devel
@@ -1,9 +1,9 @@
 FROM rocker/verse:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_geospatial_ubuntugis
+++ b/dockerfiles/Dockerfile_geospatial_ubuntugis
@@ -1,9 +1,9 @@
 FROM rocker/verse
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.0
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.0-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.0-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.0-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.0-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.1-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.1-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.1-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.1-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.2
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.2-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.2-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.2-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.2-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.3
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.3-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.3-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.3-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.3-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.3-cuda11.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.3-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.3-cuda11.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.4
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.4-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.4-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.4-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.4-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.4-cuda11.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.4-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.4-cuda11.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.5
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:4.0.5-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_4.0.5-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_4.0.5-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.5-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_devel
+++ b/dockerfiles/Dockerfile_ml-verse_devel
@@ -1,9 +1,9 @@
 FROM rocker/ml-verse:devel-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml-verse_devel-cuda10.1
+++ b/dockerfiles/Dockerfile_ml-verse_devel-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:devel-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.0
+++ b/dockerfiles/Dockerfile_ml_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.0-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.0-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.0-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.0-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.1
+++ b/dockerfiles/Dockerfile_ml_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.1-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.1-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.1-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.1-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.2
+++ b/dockerfiles/Dockerfile_ml_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.2-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.2-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.2-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.2-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.3
+++ b/dockerfiles/Dockerfile_ml_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.3-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.3-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.3-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.3-cuda11.1
+++ b/dockerfiles/Dockerfile_ml_4.0.3-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3-cuda11.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.4
+++ b/dockerfiles/Dockerfile_ml_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.4-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.4-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.4-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.4-cuda11.1
+++ b/dockerfiles/Dockerfile_ml_4.0.4-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4-cuda11.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_4.0.5
+++ b/dockerfiles/Dockerfile_ml_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/ml:4.0.5-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_4.0.5-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_4.0.5-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.5-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_ml_devel
+++ b/dockerfiles/Dockerfile_ml_devel
@@ -1,9 +1,9 @@
 FROM rocker/ml:devel-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_ml_devel-cuda10.1
+++ b/dockerfiles/Dockerfile_ml_devel-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:devel-cuda10.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_r-ver_4.0.0
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.1
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.1
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.1-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.1-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_4.0.2
+++ b/dockerfiles/Dockerfile_r-ver_4.0.2
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.2
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.2-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.2-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_4.0.3
+++ b/dockerfiles/Dockerfile_r-ver_4.0.3
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.3
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.3-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.3-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_4.0.3-cuda11.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.3-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=11.1
 ENV NCCL_VERSION=2.7.8

--- a/dockerfiles/Dockerfile_r-ver_4.0.4
+++ b/dockerfiles/Dockerfile_r-ver_4.0.4
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.4
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.4-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.4-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_4.0.4-cuda11.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.4-cuda11.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=11.1
 ENV NCCL_VERSION=2.7.8

--- a/dockerfiles/Dockerfile_r-ver_4.0.5
+++ b/dockerfiles/Dockerfile_r-ver_4.0.5
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.5
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_r-ver_devel
+++ b/dockerfiles/Dockerfile_r-ver_devel
@@ -1,9 +1,9 @@
 FROM ubuntu:20.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=devel
 ENV TERM=xterm

--- a/dockerfiles/Dockerfile_r-ver_devel-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_devel-cuda10.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
 ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1

--- a/dockerfiles/Dockerfile_rstudio_4.0.0
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.0.0.1
 ENV RSTUDIO_VERSION=1.3.959

--- a/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.0-ubuntu18.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=1.3.959

--- a/dockerfiles/Dockerfile_rstudio_4.0.1
+++ b/dockerfiles/Dockerfile_rstudio_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.0.0.1
 ENV RSTUDIO_VERSION=1.3.959

--- a/dockerfiles/Dockerfile_rstudio_4.0.2
+++ b/dockerfiles/Dockerfile_rstudio_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.0.0.1
 ENV RSTUDIO_VERSION=1.3.1093

--- a/dockerfiles/Dockerfile_rstudio_4.0.3
+++ b/dockerfiles/Dockerfile_rstudio_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_rstudio_4.0.4
+++ b/dockerfiles/Dockerfile_rstudio_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1106

--- a/dockerfiles/Dockerfile_rstudio_4.0.5
+++ b/dockerfiles/Dockerfile_rstudio_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_rstudio_4.0.5-daily
+++ b/dockerfiles/Dockerfile_rstudio_4.0.5-daily
@@ -1,9 +1,9 @@
 FROM rocker/r-ver
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=daily

--- a/dockerfiles/Dockerfile_rstudio_devel
+++ b/dockerfiles/Dockerfile_rstudio_devel
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.0
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.1
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.2
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.3
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.4
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_4.0.5
+++ b/dockerfiles/Dockerfile_shiny-verse_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/shiny:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_devel
+++ b/dockerfiles/Dockerfile_shiny-verse_devel
@@ -1,9 +1,9 @@
 FROM rocker/shiny:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_shiny_4.0.0
+++ b/dockerfiles/Dockerfile_shiny_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_4.0.1
+++ b/dockerfiles/Dockerfile_shiny_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_4.0.2
+++ b/dockerfiles/Dockerfile_shiny_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_4.0.3
+++ b/dockerfiles/Dockerfile_shiny_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_4.0.4
+++ b/dockerfiles/Dockerfile_shiny_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_4.0.5
+++ b/dockerfiles/Dockerfile_shiny_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_shiny_devel
+++ b/dockerfiles/Dockerfile_shiny_devel
@@ -1,9 +1,9 @@
 FROM rocker/r-ver:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.0-ubuntu18.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.1
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.2
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.3
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.4
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.5
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_4.0.5-daily
+++ b/dockerfiles/Dockerfile_tidyverse_4.0.5-daily
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:4.0.5-daily
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_tidyverse_devel
+++ b/dockerfiles/Dockerfile_tidyverse_devel
@@ -1,9 +1,9 @@
 FROM rocker/rstudio:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 
 

--- a/dockerfiles/Dockerfile_verse_4.0.0
+++ b/dockerfiles/Dockerfile_verse_4.0.0
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.0
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/05/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
+++ b/dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.0-ubuntu18.04
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.1
+++ b/dockerfiles/Dockerfile_verse_4.0.1
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.1
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/21/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.2
+++ b/dockerfiles/Dockerfile_verse_4.0.2
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.2
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/10/07/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.3
+++ b/dockerfiles/Dockerfile_verse_4.0.3
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.3
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/02/14/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.4
+++ b/dockerfiles/Dockerfile_verse_4.0.4
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.4
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/03/30/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.5
+++ b/dockerfiles/Dockerfile_verse_4.0.5
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.5
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_4.0.5-daily
+++ b/dockerfiles/Dockerfile_verse_4.0.5-daily
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:4.0.5-daily
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/dockerfiles/Dockerfile_verse_devel
+++ b/dockerfiles/Dockerfile_verse_devel
@@ -1,9 +1,9 @@
 FROM rocker/tidyverse:devel
 
-LABEL org.label-schema.license="GPL-2.0" \
-      org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
-      org.label-schema.vendor="Rocker Project" \
-      maintainer="Carl Boettiger <cboettig@ropensci.org>"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/stacks/binder-4.0.0.json
+++ b/stacks/binder-4.0.0.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-4.0.1.json
+++ b/stacks/binder-4.0.1.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-4.0.2.json
+++ b/stacks/binder-4.0.2.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-4.0.3.json
+++ b/stacks/binder-4.0.3.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-4.0.4.json
+++ b/stacks/binder-4.0.4.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-4.0.5.json
+++ b/stacks/binder-4.0.5.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 {
     "IMAGE": "binder",

--- a/stacks/binder-devel.json
+++ b/stacks/binder-devel.json
@@ -1,6 +1,6 @@
 {
 "ordered": false,
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
 
 {

--- a/stacks/core-4.0.0-ubuntu18.04.json
+++ b/stacks/core-4.0.0-ubuntu18.04.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.0-ubuntu18.04",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 
   "stack": [
   {

--- a/stacks/core-4.0.0.json
+++ b/stacks/core-4.0.0.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.0",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.1.json
+++ b/stacks/core-4.0.1.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.2.json
+++ b/stacks/core-4.0.2.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.2",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.3.json
+++ b/stacks/core-4.0.3.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.3",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.4.json
+++ b/stacks/core-4.0.4.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.4",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-4.0.5-daily.json
+++ b/stacks/core-4.0.5-daily.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.5-daily",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "rstudio",

--- a/stacks/core-4.0.5.json
+++ b/stacks/core-4.0.5.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.5",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/core-devel.json
+++ b/stacks/core-devel.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "devel",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/geospatial-4.0.0-ubuntu18.04.json
+++ b/stacks/geospatial-4.0.0-ubuntu18.04.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.0-ubuntu18.04",

--- a/stacks/geospatial-4.0.0.json
+++ b/stacks/geospatial-4.0.0.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.0",

--- a/stacks/geospatial-4.0.1.json
+++ b/stacks/geospatial-4.0.1.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.1",

--- a/stacks/geospatial-4.0.2.json
+++ b/stacks/geospatial-4.0.2.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.2",

--- a/stacks/geospatial-4.0.3.json
+++ b/stacks/geospatial-4.0.3.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.3",

--- a/stacks/geospatial-4.0.4-daily.json
+++ b/stacks/geospatial-4.0.4-daily.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.4-daily",

--- a/stacks/geospatial-4.0.4.json
+++ b/stacks/geospatial-4.0.4.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.4",

--- a/stacks/geospatial-4.0.5.json
+++ b/stacks/geospatial-4.0.5.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "4.0.5",

--- a/stacks/geospatial-dev-osgeo.json
+++ b/stacks/geospatial-dev-osgeo.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "dev-osgeo",

--- a/stacks/geospatial-devel.json
+++ b/stacks/geospatial-devel.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "devel",

--- a/stacks/geospatial-ubuntugis.json
+++ b/stacks/geospatial-ubuntugis.json
@@ -1,7 +1,7 @@
 {
 "ordered": false,
 "IMAGE": "geospatial",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
 "stack": [
   {
     "TAG": "ubuntugis",

--- a/stacks/ml-cuda10.1-4.0.0.json
+++ b/stacks/ml-cuda10.1-4.0.0.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.0-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-4.0.1.json
+++ b/stacks/ml-cuda10.1-4.0.1.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.1-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-4.0.2.json
+++ b/stacks/ml-cuda10.1-4.0.2.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.2-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-4.0.3.json
+++ b/stacks/ml-cuda10.1-4.0.3.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.3-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-4.0.4.json
+++ b/stacks/ml-cuda10.1-4.0.4.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.4-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-4.0.5.json
+++ b/stacks/ml-cuda10.1-4.0.5.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.5-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda10.1-devel.json
+++ b/stacks/ml-cuda10.1-devel.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "devel-cuda10.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda11.1-4.0.3.json
+++ b/stacks/ml-cuda11.1-4.0.3.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.3-cuda11.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/ml-cuda11.1-4.0.4.json
+++ b/stacks/ml-cuda11.1-4.0.4.json
@@ -2,7 +2,7 @@
   "ordered": true,
   "latest": true,
   "TAG": "4.0.4-cuda11.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "r-ver",

--- a/stacks/shiny-4.0.0.json
+++ b/stacks/shiny-4.0.0.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.0",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-4.0.1.json
+++ b/stacks/shiny-4.0.1.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.1",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-4.0.2.json
+++ b/stacks/shiny-4.0.2.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.2",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-4.0.3.json
+++ b/stacks/shiny-4.0.3.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.3",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-4.0.4.json
+++ b/stacks/shiny-4.0.4.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.4",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-4.0.5.json
+++ b/stacks/shiny-4.0.5.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "4.0.5",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",

--- a/stacks/shiny-devel.json
+++ b/stacks/shiny-devel.json
@@ -1,7 +1,7 @@
 {
   "ordered": true,
   "TAG": "devel",
-  "LABEL": "org.label-schema.license=\"GPL-2.0\" \\\n      org.label-schema.vcs-url=\"https://github.com/rocker-org/rocker-versioned\" \\\n      org.label-schema.vendor=\"Rocker Project\" \\\n      maintainer=\"Carl Boettiger <cboettig@ropensci.org>\"",
+  "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "stack": [
   {
     "IMAGE": "shiny",


### PR DESCRIPTION
# Motivation

I noticed a mistake in the URL on LABEL.
Also, [the Label Schema](https://github.com/label-schema/label-schema.org/blob/gh-pages/rc1.md) was deprecated two years ago and I thought it would be better to replace it with the currently recommended [the OCI annotations](https://github.com/opencontainers/image-spec/blob/master/annotations.md).

Fixes #148.

# Details of changes

1. Replace labels with [OCI Pre-Defined Annotation Keys](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys)
    1. `org.label-schema.vcs-url` and `org.label-schema.vendor` are replaced by `org.opencontainers.image.source` and `org.opencontainers.image.vendor` for  [compatibility](https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema).
    2. `org.label-schema.license` is replaced by `org.opencontainers.image.licenses` and changed to [an SPDX License Expression `GPL-2.0-or-later`](https://spdx.org/licenses/GPL-2.0-or-later.html).
    3. `maintainer` is replaced by `org.opencontainers.image.authors`, which means contact details of the people or organization responsible for the image.
2. Modify the URL pointing to this repository, `https://github.com/rocker-org/rocker-versioned` to `https://github.com/rocker-org/rocker-versioned2`.

# Changed files

This PR modifies the following files:
1. 43 files in `stacks/`
2. 112 dockerfiles generated from `stacks/`

```shell
$ ls stacks/ | wc -w
43
$ ls dockerfiles/ | wc -w
112
```

# Example of OCI annotation
- docker's GitHub Actions https://github.com/docker/build-push-action/blob/master/UPGRADE.md
- [docker-library/repo-info](https://github.com/search?q=org%3Adocker-library+org.opencontainers.image&type=Code)

# Other Reference
https://github.com/rocker-org/rocker/issues/23