### PR TITLE
Update the `install_R_ppa.sh` script

### DIFF
--- a/scripts/install_R_ppa.sh
+++ b/scripts/install_R_ppa.sh
@@ -15,7 +15,7 @@ CRAN_SOURCE=${CRAN/"__linux__/$UBUNTU_VERSION/"/""}
 export DEBIAN_FRONTEND=noninteractive
 
 # Set up and install R
-R_HOME=${R_HOME:-/usr/local/lib/R}
+R_HOME=${R_HOME:-/usr/lib/R}
 
 READLINE_VERSION=8
 OPENBLAS=libopenblas-dev


### PR DESCRIPTION
I was curious, so I tried a multi-architecture build of amd64 and arm64 with the same contents as `rocker/r-ver` using the script in this repository, but it took about 2 hours to build R4.0.5 alone.
https://github.com/eitsupi/r-ver

So I decided to switch to installing from PPA to save time, and noticed that `install_R_ppa.sh` had not been updated for a long time compared to `install_R.sh`.
I have tried to reflect the changes made to `install_R.sh`, so please merge it if you want. If you don't need it, please close this PR.

There are many things I don't understand about this script, so if you can advise me I will fix it.

~~By the way, I was not able to build a arm64 image even from Ubuntu 18.04 with this modified script, so I ended up reverting to building R from the source code.......~~
(Update) I completely misunderstood, I get that there is no arm version build in the PPA.