### PR TITLE
Add installation of libcurl to `install_tidyverse.sh`

### DIFF
--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -14,6 +14,7 @@ apt-get update -qq && apt-get -y --no-install-recommends install \
     libsqlite3-dev \
     libssh2-1-dev \
     libxtst6 \
+    libcurl4-openssl-dev \
     unixodbc-dev && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Attempts to install the `tidyverse` package from source by using the `install_tidyverse.sh` script will fail due to the lack of `libcurl4-openssl-dev`.
`libcurl4-openssl-dev` is a dependency of [the `curl` package](https://github.com/jeroen/curl#installation).

We can confirm that the `curl` package cannot be installed on `rocker/r-ver:devel` without `libcurl4-openssl-dev` with the following command.

```shell
$ docker run --rm -it rocker/r-ver:devel install2.r curl
```

tested image digest: `rocker/r-ver@sha256:300b6a99e37594b4829787f311f68769491e56acbe40c6225f851503d15942a2`

NOTE
Since `rocker/rstudio:devel` has `libcurl4-openssl-dev` installed by the `install_rstudio.sh`, the `curl` package installation will not fail.
Similarly, `rocker/shiny:devel` has `libcurl4-gnutls-dev` installed by `install_shiny_server.sh`, so it doesn't seem to fail to install the `curl` package. 