### PR TITLE
Remove the authentication cookie file

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -68,7 +68,7 @@ dpkg -i rstudio-server-*-amd64.deb
 rm rstudio-server-*-amd64.deb
 
 # https://github.com/rocker-org/rocker-versioned2/issues/137
-rm -f /var/lib/rstudio-server/secret-cookie-key
+rm -f /var/lib/rstudio-server/secure-cookie-key
 
 ## RStudio wants an /etc/R, will populate from $R_HOME/etc
 mkdir -p /etc/R


### PR DESCRIPTION
Fixes #137 #165

```shell
$ docker run --rm -it rocker/rstudio:4.1.0 ls -l /var/lib/rstudio-server/
total 36
drwxr-xr-x 2 root           root            4096 May 23 21:57 body
drwxr-xr-x 2 root           root            4096 May 23 21:57 conf
drwxr-xr-x 2 root           root            4096 May 23 21:57 proxy
-rw-r--r-- 1 rstudio-server rstudio-server 20480 May 23 21:57 rstudio.sqlite
-rw------- 1 root           root              32 May 23 21:57 secure-cookie-key
```