### PR TITLE
Set automatic-update commits' author to bot

### DIFF
--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -23,6 +23,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Automatic update of container definition files
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           signoff: false
           branch: auto-detected-updates
           delete-branch: true


### PR DESCRIPTION
Change the author of the commit created by GitHubActions to bot.

Currently, the author is set to the person who committed to the default branch immediately before, which can cause confusion in automatic version-up workflow such as this one.
(I apologize for the insufficient work I did on #164.)

See the create-pull-request action documentation for details.
https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md#updating-from-v2-to-v3

I have tested it here.
https://github.com/eitsupi/rocker-versioned2/pull/6
![image](https://user-images.githubusercontent.com/50911393/120926097-7faa3080-c716-11eb-8aa8-fc5117822b87.png)