### PR TITLE
Update build core image action to push `latest` tagged images

### DIFF
--- a/.github/workflows/buildmatrix/latest.json
+++ b/.github/workflows/buildmatrix/latest.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    {
+      "r_version": "4.1.0",
+      "r_latest": true
+    }
+  ]
+}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,19 +1,57 @@
 name: Build & Push Core images
 
-'on': [push]
-#  release:
-#    types: [published]
+on:
+  push:
+    paths:
+      - ".github/workflows/buildmatrix/**"
+      - "scripts/**"
+      - "dockerfiles/Dockerfile_r-ver_*"
+      - "dockerfiles/Dockerfile_rstudio_*"
+      - "dockerfiles/Dockerfile_tidyverse_*"
+      - "dockerfiles/Dockerfile_verse_*"
 
 jobs:
-  build:
+  generate_matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - id: set-json
+        run: |
+          JSON=.github/workflows/buildmatrix/latest.json
+          echo ::set-output name=json::${JSON}
+          echo ${JSON}
+      - id: set-matrix
+        run: |
+          CONTENT=$(jq -r 'tostring' ${{ steps.set-json.outputs.json }})
+          echo ::set-output name=matrix::${CONTENT}
+          echo ${CONTENT}
+
+  build:
+    needs: generate_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
       - uses: docker/login-action@v1
         with:
-            username: ${{ secrets.DOCKER_USER }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build the tagged Docker image
-        run: docker-compose -f compose/core-4.1.0.yml build
+        run: docker-compose -f compose/core-${{ matrix.r_version }}.yml build
       - name: Push the tagged Docker image
-        run: docker-compose  -f compose/core-4.1.0.yml push
+        run: docker-compose -f compose/core-${{ matrix.r_version }}.yml push
+      - name: Push latest tagged Docker image
+        if: matrix.r_latest == true
+        run: |
+          docker image tag rocker/r-ver:${{ matrix.r_version }} rocker/r-ver:latest
+          docker image tag rocker/rstudio:${{ matrix.r_version }} rocker/rstudio:latest
+          docker image tag rocker/tidyverse:${{ matrix.r_version }} rocker/tidyverse:latest
+          docker image tag rocker/verse:${{ matrix.r_version }} rocker/verse:latest
+          docker image push rocker/r-ver:latest
+          docker image push rocker/rstudio:latest
+          docker image push rocker/tidyverse:latest
+          docker image push rocker/verse:latest

--- a/make-stacks.R
+++ b/make-stacks.R
@@ -174,6 +174,15 @@ df_args <- .r_versions_data(min_version = 4.0) %>%
     dplyr::rename(r_version = version) %>%
     dplyr::select(!tidyselect::ends_with("_date"))
 
+# Write json file for GitHubActions build matrix.
+df_args %>%
+    dplyr::select(r_version, r_latest) %>%
+    utils::tail(1) %>%
+    {
+        list(include = .)
+    } %>%
+    jsonlite::write_json(".github/workflows/buildmatrix/latest.json", pretty = TRUE, auto_unbox = TRUE)
+
 message("\nstart writing stack files.")
 
 # Write stack core files.


### PR DESCRIPTION
Suggested by https://github.com/rocker-org/rocker-versioned2/pull/164#issuecomment-854841158

Make the following updates.

1. `make-stacks.R` will generate a new json file for the build matrix.
2. The `core.yml` will read the version of R to be built from the build matrix, and if R is the latest version, it will also push images with `latest` tag.
3. Limit the conditions under which `core.yml` is executed to only when a specific file is modified.

These changes will clarify the update timing of images on DockerHub, and images with the `latest` tag will always follow the latest R version.

**Note**
1. I haven't been able to fully debug it because I can't log in to DockerHub, but I have confirmed that the `if: matrix.r_latest == true` method to determine the latest version is working. https://github.com/eitsupi/rocker-versioned2/actions/runs/912039914
![image](https://user-images.githubusercontent.com/50911393/121006709-2d2b4b80-c7cc-11eb-99c8-6b5bab207b38.png)
![image](https://user-images.githubusercontent.com/50911393/121006590-0240f780-c7cc-11eb-9e6e-3282d9055a0b.png)
![image](https://user-images.githubusercontent.com/50911393/121006510-efc6be00-c7cb-11eb-9204-f91523f0d412.png)
2. In this PR, only the `core.yml` has been changed, but if there is no problem with the behavior, I would like to apply the same changes to other workflows that build other images.
3. The current build matrix includes only one version, so the latest version can be determined without `r_latest` in the build matrix, but it is included in case you need to build multiple versions at the same time in the future.