### PR TITLE
fix latest tagged images

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - ".github/workflows/buildmatrix/**"
+      - ".github/workflows/core.yml"
       - "scripts/**"
       - "dockerfiles/Dockerfile_r-ver_*"
       - "dockerfiles/Dockerfile_rstudio_*"


### PR DESCRIPTION
@cboettig I'm very sorry.
The workflow worked fine, but I misspelled the image name and accidentally pushed the `rocker/verse:4.1.0` as the latest of another image in #175.
If you merge this PR, the build will be done again and the correct images will be pushed.

![image](https://user-images.githubusercontent.com/50911393/122095091-e1ba1280-ce47-11eb-86b7-90c795c89654.png)
![image](https://user-images.githubusercontent.com/50911393/122095236-1332de00-ce48-11eb-9eed-66fad7ac915d.png)