### PR TITLE
Use docker/build-push-action for build "core" images

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,19 +1,126 @@
 name: Build & Push Core images
 
-'on': [push]
-#  release:
-#    types: [published]
+on:
+  push:
+    paths:
+      - "dockerfiles"
+      - "scripts"
+      - ".github/workflows/core.yml"
 
 jobs:
-  build:
+  generate_matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: |
+          CONTENT=$(jq -r 'tostring' buildmatrix.json)
+          echo ::set-output name=matrix::${CONTENT}
+          echo ${CONTENT}
+
+  build:
+    needs: generate_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
+    steps:
+      - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
-            username: ${{ secrets.DOCKER_USER }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build the tagged Docker image
-        run: docker-compose -f compose/core-4.1.0.yml build
-      - name: Push the tagged Docker image
-        run: docker-compose  -f compose/core-4.1.0.yml push
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Build & Push rocker/r-ver
+
+      - name: Prepare r-ver
+        id: prep-r-ver
+        run: |
+          DOCKER_IMAGE="rocker/r-ver"
+          TAGS="$DOCKER_IMAGE:${{ matrix.r_version }}"
+          if "${{ matrix.r_latest }}"; then
+            TAGS="$TAGS,$DOCKER_IMAGE:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ${TAGS}
+
+      - name: Build and push r-ver
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dockerfiles/Dockerfile_r-ver_${{ matrix.r_version }}
+          tags: ${{ steps.prep-r-ver.outputs.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      # Build & Push rocker/rstudio
+
+      - name: Prepare rstudio
+        id: prep-rstudio
+        run: |
+          DOCKER_IMAGE="rocker/rstudio"
+          TAGS="$DOCKER_IMAGE:${{ matrix.r_version }}"
+          if "${{ matrix.r_latest }}"; then
+            TAGS="$TAGS,$DOCKER_IMAGE:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ${TAGS}
+
+      - name: Build and push rstudio
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dockerfiles/Dockerfile_rstudio_${{ matrix.r_version }}
+          tags: ${{ steps.prep-rstudio.outputs.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      # Build & Push rocker/tidyverse
+
+      - name: Prepare tidyverse
+        id: prep-tidyverse
+        run: |
+          DOCKER_IMAGE="rocker/tidyverse"
+          TAGS="$DOCKER_IMAGE:${{ matrix.r_version }}"
+          if "${{ matrix.r_latest }}"; then
+            TAGS="$TAGS,$DOCKER_IMAGE:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ${TAGS}
+
+      - name: Build and push tidyverse
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dockerfiles/Dockerfile_tidyverse_${{ matrix.r_version }}
+          tags: ${{ steps.prep-tidyverse.outputs.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      # Build & Push rocker/verse
+
+      - name: Prepare verse
+        id: prep-verse
+        run: |
+          DOCKER_IMAGE="rocker/verse"
+          TAGS="$DOCKER_IMAGE:${{ matrix.r_version }}"
+          if "${{ matrix.r_latest }}"; then
+            TAGS="$TAGS,$DOCKER_IMAGE:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ${TAGS}
+
+      - name: Build and push verse
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dockerfiles/Dockerfile_verse_${{ matrix.r_version }}
+          tags: ${{ steps.prep-verse.outputs.tags }}
+          push: true
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/buildmatrix.json
+++ b/buildmatrix.json
@@ -1,0 +1,32 @@
+{
+  "include": [
+    {
+      "r_version": "4.0.0",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.1",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.2",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.3",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.4",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.5",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.1.0",
+      "r_latest": true
+    }
+  ]
+}

--- a/make-stacks.R
+++ b/make-stacks.R
@@ -174,6 +174,14 @@ df_args <- .r_versions_data(min_version = 4.0) %>%
     dplyr::rename(r_version = version) %>%
     dplyr::select(!tidyselect::ends_with("_date"))
 
+# Write json file for GitHubActions build matrix.
+df_args %>%
+    dplyr::select(r_version, r_latest) %>%
+    {
+        list(include = .)
+    } %>%
+    jsonlite::write_json("buildmatrix.json", pretty = TRUE, auto_unbox = TRUE)
+
 message("\nstart writing stack files.")
 
 # Write stack core files.


### PR DESCRIPTION
Change from the current build method using docker-compose to using buildx in [docker/build-push-action](https://github.com/docker/build-push-action).
We will be able to make more detailed settings, such as setting multiple tags.

This PR is what I had prepared before #169, but it was replaced by #169 because the workflow definition had become very complex and difficult to reproduce locally.