### PR TITLE
use etc/Renviron.site and not etc/Renviron

### DIFF
--- a/compose/ml-cuda10.1-4.1.0.yml
+++ b/compose/ml-cuda10.1-4.1.0.yml
@@ -1,21 +1,21 @@
 version: '3'
 services:
-  r-ver-4.1.0-cuda11.1:
-    image: rocker/r-ver:4.1.0-cuda11.1
+  r-ver-4.1.0-cuda10.1:
+    image: rocker/r-ver:4.1.0-cuda10.1
     build:
       context: ..
-      dockerfile: dockerfiles/Dockerfile_r-ver_4.1.0-cuda11.1
-  ml-4.1.0-cuda11.1:
-    image: rocker/ml:4.1.0-cuda11.1
+      dockerfile: dockerfiles/Dockerfile_r-ver_4.1.0-cuda10.1
+  ml-4.1.0-cuda10.1:
+    image: rocker/ml:4.1.0-cuda10.1
     depends_on:
-    - r-ver-4.1.0-cuda11.1
+    - r-ver-4.1.0-cuda10.1
     build:
       context: ..
-      dockerfile: dockerfiles/Dockerfile_ml_4.1.0-cuda11.1
-  ml-verse-4.1.0-cuda11.1:
-    image: rocker/ml-verse:4.1.0-cuda11.1
+      dockerfile: dockerfiles/Dockerfile_ml_4.1.0-cuda10.1
+  ml-verse-4.1.0-cuda10.1:
+    image: rocker/ml-verse:4.1.0-cuda10.1
     depends_on:
-    - ml-4.1.0-cuda11.1
+    - ml-4.1.0-cuda10.1
     build:
       context: ..
-      dockerfile: dockerfiles/Dockerfile_ml-verse_4.1.0-cuda11.1
+      dockerfile: dockerfiles/Dockerfile_ml-verse_4.1.0-cuda10.1

--- a/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
+++ b/dockerfiles/Dockerfile_r-ver_4.0.5-cuda10.1
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CUDA_VERSION=10.1.243
-ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_REQUIRE_CUDA=cuda>=10.1 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=396,driver<397 brand=tesla,driver>=410,driver<411

--- a/scripts/config_R_cuda.sh
+++ b/scripts/config_R_cuda.sh
@@ -11,8 +11,8 @@ NVBLAS_CONFIG_FILE=${NVBLAS_CONFIG_FILE:-/etc/nvblas.conf}
 
 ## cli R inherits these, but RStudio needs to have these set in as follows:
 ## (From https://tensorflow.rstudio.com/tools/local_gpu.html#environment-variables)
-echo "CUDA_HOME=$CUDA_HOME" >> ${R_HOME}/etc/Renviron
-echo "PATH=$PATH" >> ${R_HOME}/etc/Renviron
+echo "CUDA_HOME=$CUDA_HOME" >> ${R_HOME}/etc/Renviron.site
+echo "PATH=$PATH" >> ${R_HOME}/etc/Renviron.site
 
 if test -f /etc/rstudio/rserver.conf; then
   sed -i '/^rsession-ld-library-path/d' /etc/rstudio/rserver.conf
@@ -29,7 +29,7 @@ echo 'NVBLAS_LOGFILE /var/log/nvblas.log
 NVBLAS_CPU_BLAS_LIB /usr/lib/x86_64-linux-gnu/openblas/libblas.so.3
 NVBLAS_GPU_LIST ALL' > /etc/nvblas.conf
 
-echo "NVBLAS_CONFIG_FILE=$NVBLAS_CONFIG_FILE" >> ${R_HOME}/etc/Renviron
+echo "NVBLAS_CONFIG_FILE=$NVBLAS_CONFIG_FILE" >> ${R_HOME}/etc/Renviron.site
 
 ## We don't want to set LD_PRELOAD globally
 ##ENV LD_PRELOAD=/usr/local/cuda/lib64/libnvblas.so

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -140,8 +140,8 @@ chown root:staff ${R_HOME}/site-library
 chmod g+ws ${R_HOME}/site-library
 
 ## Fix library path
-echo "R_LIBS=\${R_LIBS-'${R_HOME}/site-library:${R_HOME}/library'}" >> ${R_HOME}/etc/Renviron
-echo "TZ=${TZ}" >> ${R_HOME}/etc/Renviron
+echo "R_LIBS=\${R_LIBS-'${R_HOME}/site-library:${R_HOME}/library'}" >> ${R_HOME}/etc/Renviron.site
+echo "TZ=${TZ}" >> ${R_HOME}/etc/Renviron.site
 
 ## Use littler installation scripts
 Rscript -e "install.packages(c('littler', 'docopt'), repos='${CRAN_SOURCE}')"

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -15,7 +15,7 @@ usermod -l ${NB_USER} rstudio
 mkdir -p ${PYTHON_VENV_PATH} && chown -R ${NB_USER} ${PYTHON_VENV_PATH}
 
 # And set ENV for R! It doesn't read from the environment...
-echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
+echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron.site
 echo "export PATH=${PATH}" >> ${WORKDIR}/.profile
 
 ## This gets run as user

--- a/scripts/install_pyenv.sh
+++ b/scripts/install_pyenv.sh
@@ -10,6 +10,8 @@ set -e
 
 
 PYTHON_CONFIGURE_OPTS=${PYTHON_CONFIGURE_OPTS:-"--enable-shared"}
+echo "PYTHON_CONFIGURE_OPTS=$PYTHON_CONFIGURE_OPTS" >> ${R_HOME}/etc/R_environ
+
 
 apt-get update && apt-get -y install curl python3-pip
 python3 -m pip --no-cache-dir install --upgrade --ignore-installed pipenv
@@ -20,7 +22,7 @@ curl https://pyenv.run | bash
 mv /root/.pyenv /opt/pyenv
 
 # pipenv requires ~/.local/bin to be on the path...
-echo "PATH=/opt/pyenv/bin:~/.local/bin:$PATH" >> ${R_HOME}/etc/Renviron
+echo "PATH=/opt/pyenv/bin:~/.local/bin:$PATH" >> ${R_HOME}/etc/Renviron.site
 echo "PATH=/opt/pyenv/bin:~/.local/bin:$PATH" >> /etc/bash.bashrc
 echo 'eval "$(pyenv init --path)"' >>  /etc/bash.bashrc
 echo 'eval "$(pyenv virtualenv-init -)"' >> /etc/bash.bashrc

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -32,9 +32,9 @@ python3 -m venv ${PYTHON_VENV_PATH}
 install2.r --skipinstalled --error reticulate
 
 ## Ensure RStudio inherits this env var
-echo "" >> ${R_HOME}/etc/Renviron
-echo "WORKON_HOME=${WORKON_HOME}" >> ${R_HOME}/etc/Renviron
-echo "RETICULATE_MINICONDA_ENABLED=${RETICULATE_MINICONDA_ENABLED}" >> ${R_HOME}/etc/Renviron
+echo "" >> ${R_HOME}/etc/Renviron.site
+echo "WORKON_HOME=${WORKON_HOME}" >> ${R_HOME}/etc/Renviron.site
+echo "RETICULATE_MINICONDA_ENABLED=${RETICULATE_MINICONDA_ENABLED}" >> ${R_HOME}/etc/Renviron.site
 
 
 ## symlink these so that these are available when switching to a new venv

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -72,7 +72,7 @@ rm -f /var/lib/rstudio-server/secure-cookie-key
 
 ## RStudio wants an /etc/R, will populate from $R_HOME/etc
 mkdir -p /etc/R
-echo "PATH=${PATH}" >> "${R_HOME}/etc/Renviron"
+echo "PATH=${PATH}" >> "${R_HOME}/etc/Renviron.site"
 
 ## Make RStudio compatible with case when R is built from source
 ## (and thus is at /usr/local/bin/R), because RStudio doesn't obey

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -29,7 +29,7 @@ tlmgr install ae bibtex context inconsolata listings makeindex metafont mfware p
 ## do not add to /usr/local/bin
 # tlmgr path add
 # instead, we keep binaries separate and add to PATH
-echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
+echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron.site
 
 ## open permissions to avoid needless warnings
 chown -R rstudio:staff /opt/texlive

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -9,7 +9,7 @@ ROOT=${ROOT:=FALSE}
 UMASK=${UMASK:=022}
 
 ## Make sure RStudio inherits the full path
-echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
+echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron.site
 
 bold=$(tput bold)
 normal=$(tput sgr0)

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -97,5 +97,5 @@ if [ "$UMASK" -ne 022 ]
 fi
 
 ## add these to the global environment so they are avialable to the RStudio user
-echo "HTTR_LOCALHOST=$HTTR_LOCALHOST" >> /etc/R/Renviron.site
-echo "HTTR_PORT=$HTTR_PORT" >> /etc/R/Renviron.site
+echo "HTTR_LOCALHOST=$HTTR_LOCALHOST" >> ${R_HOME}/etc/Renviron.site
+echo "HTTR_PORT=$HTTR_PORT" >> ${R_HOME}/etc/Renviron.site


### PR DESCRIPTION
As noted in #151, we are better off appending to `R_HOME/etc/Renviron.site` and not modifying the system `R_HOME/etc/Renviron` as discussed in https://support.rstudio.com/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf

(functionally I am not sure this changes anything, as the previous version only appended to `R_HOME/etc/Renviron`, though certainly modifying or deleting any of the system `R_HOME/etc/Renviron` settings would be bad.  In any event writing to a separate file is always cleaner).  

 @eitsupi @Pit-Storm would you care to take a look over the proposed changes?