### PR TITLE
Change the triggers for build workflows

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -2,6 +2,8 @@ name: Build & Push Core images
 
 on:
   push:
+    branches:
+      - "master"
     paths:
       - ".github/workflows/buildmatrix/**"
       - ".github/workflows/core.yml"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -6,12 +6,12 @@ on:
       - "master"
     paths:
       - ".github/workflows/buildmatrix/**"
-      - ".github/workflows/core.yml"
       - "scripts/**"
       - "dockerfiles/Dockerfile_r-ver_*"
       - "dockerfiles/Dockerfile_rstudio_*"
       - "dockerfiles/Dockerfile_tidyverse_*"
       - "dockerfiles/Dockerfile_verse_*"
+  workflow_dispatch:
 
 jobs:
   generate_matrix:

--- a/.github/workflows/ml-10.1.yml
+++ b/.github/workflows/ml-10.1.yml
@@ -1,8 +1,9 @@
 name: ml-cuda-10.1
 
-'on': [push]
-#  release:
-#    types: [published]
+on:
+  push:
+    branches:
+      - "master"
 
 jobs:
   build:


### PR DESCRIPTION
I noticed by #183 that the images was being pushed to DockerHub even when it was pushed to a branch other than the default branch because we hadn't specified the branch in the workflow's execution condition.
This is not a desirable behavior and will be fixed.

And, I thought it was undesirable to have the workflow run with such workflow changes that do not affect the contents of the container being built, so I excluded the change of `core.yml` from the trigger and allowed it to be executed manually instead.

**Note**: I think the execution condition of `ml-10.1.yml` should be success of `core.yml` because ml-cuda10.1 is originally derived from `rocker/r-ver`, but I left it as it is because of the discussion in #182.