### PR TITLE
Fix the Home environment variable in RStudio

### DIFF
--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -108,9 +108,12 @@ fi
 echo "HTTR_LOCALHOST=$HTTR_LOCALHOST" >> ${R_HOME}/etc/Renviron.site
 echo "HTTR_PORT=$HTTR_PORT" >> ${R_HOME}/etc/Renviron.site
 ## Set our dynamic variables in Renviron.site to be reflected by RStudio
-for file in /var/run/s6/container_environment/*;
-    do echo "${file##*/}=$(cat $file)" >> ${R_HOME}/etc/Renviron.site;
-done;
+for file in /var/run/s6/container_environment/*
+do
+  if [ "${file##*/}" != "HOME" ]; then
+    echo "${file##*/}=$(cat $file)" >> ${R_HOME}/etc/Renviron.site
+  fi
+done
 
 ## Update Locale if needed
 if [ "$LANG" !=  "en_US.UTF-8" ]


### PR DESCRIPTION
Fix #188

To check, create a Dockerfile like the following, build the image, and overwrite `/etc/cont-init.d/userconf` with `userconf.sh` included in the changes

```dockerfile
FROM rocker/rstudio@sha256:04330edd2eba217f1fd196fef3be4c49a54901724fd4f30b8c9c4684a1ca4057

COPY userconf.sh /etc/cont-init.d/userconf
```

I'm submitting this because I think it's urgent, but if you think this fix is inappropriate, please close it.

cc @Pit-Storm