### PR TITLE
Update some scripts to install R packages from source, on arm64 images

### DIFF
--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -11,6 +11,11 @@ CRAN=${CRAN:-https://cran.r-project.org}
 ##  mechanism to force source installs if we're using RSPM
 CRAN_SOURCE=${CRAN/"__linux__/$UBUNTU_VERSION/"/""}
 
+## source install if using RSPM and arm64 image
+if [ "$(uname -m)" = "aarch64" ]; then
+    CRAN=$CRAN_SOURCE
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 
 # Set up and install R

--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -18,7 +18,7 @@ apt-get update -qq && apt-get -y --no-install-recommends install \
     unixodbc-dev && \
   rm -rf /var/lib/apt/lists/*
 
-install2.r --error --skipinstalled -r $CRAN -n $NCPUS \
+install2.r --error --skipinstalled -n $NCPUS \
     tidyverse \
     devtools \
     rmarkdown \
@@ -27,7 +27,7 @@ install2.r --error --skipinstalled -r $CRAN -n $NCPUS \
     gert
 
 ## dplyr database backends
-install2.r --error --skipinstalled -r $CRAN -n $NCPUS \
+install2.r --error --skipinstalled -n $NCPUS \
     arrow \
     dbplyr \
     DBI \
@@ -40,6 +40,6 @@ install2.r --error --skipinstalled -r $CRAN -n $NCPUS \
     fst
 
 ## a bridge to far? -- brings in another 60 packages
-# install2.r --error --skipinstalled -r $CRAN -n $NCPUS tidymodels
+# install2.r --error --skipinstalled -n $NCPUS tidymodels
 
  rm -rf /tmp/downloaded_packages

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -49,7 +49,7 @@ fi
 # So: we can build the redland package bindings and then swap back to libcurl-openssl-dev... (ick)
 # explicitly install runtime library sub-deps of librdf0-dev so they are not auto-removed.
 apt-get install -y librdf0-dev
-install2.r --error --skipinstalled -r redland
+install2.r --error --skipinstalled redland
 apt-get install -y \
 	libcurl4-openssl-dev \
 	libxslt-dev \
@@ -70,8 +70,8 @@ wget "https://travis-bin.yihui.name/texlive-local.deb" \
 ## Install texlive
 /rocker_scripts/install_texlive.sh
 
-install2.r --error -r --skipinstalled tinytex
-install2.r --error --deps TRUE -r --skipinstalled \
+install2.r --error --skipinstalled tinytex
+install2.r --error --deps TRUE --skipinstalled \
     blogdown bookdown rticles rmdshower rJava xaringan
 
 rm -rf /tmp/downloaded_packages

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -49,7 +49,7 @@ fi
 # So: we can build the redland package bindings and then swap back to libcurl-openssl-dev... (ick)
 # explicitly install runtime library sub-deps of librdf0-dev so they are not auto-removed.
 apt-get install -y librdf0-dev
-install2.r --error --skipinstalled -r $CRAN redland
+install2.r --error --skipinstalled -r redland
 apt-get install -y \
 	libcurl4-openssl-dev \
 	libxslt-dev \
@@ -70,8 +70,8 @@ wget "https://travis-bin.yihui.name/texlive-local.deb" \
 ## Install texlive
 /rocker_scripts/install_texlive.sh
 
-install2.r --error -r $CRAN --skipinstalled tinytex
-install2.r --error --deps TRUE -r $CRAN --skipinstalled \
+install2.r --error -r --skipinstalled tinytex
+install2.r --error --deps TRUE -r --skipinstalled \
     blogdown bookdown rticles rmdshower rJava xaringan
 
 rm -rf /tmp/downloaded_packages


### PR DESCRIPTION
Related to #144

The RSPM CRAN mirrors does not provide arm64 binary packages for ubuntu at this time.
So, in this PR, I will modify the rocker script so that the R package will do source installations in the arm64 images.

- `install_R.sh`: Change the default repository to be written to `Rprofile.site` to source in arm64 images.
- `install_tidyverse.sh` and `install_verse.sh`: Remove the reference to the CRAN env var from the options of the `install2.r` command for to use the default repository. (In other scripts originally did not reference the CRAN env var from the `install2.r` `-r` option.)

With these fixes, I have run `install_R.sh` on the `ubuntu:forcal` arm64 image, and `install_tidyverse.sh` on it, and confirmed that I can use R normally.