### PR TITLE
Set the rocker/rstudio default non-root user's login shell to bash

### DIFF
--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -5,10 +5,8 @@ if id -u "${user}" >/dev/null 2>&1; then
 else
   ## Need to configure non-root user for RStudio
   DEFAULT_USER=${1:-${DEFAULT_USER:-rstudio}}
-  useradd -s /bin/bash $DEFAULT_USER
+  useradd -s /bin/bash -m $DEFAULT_USER
   echo "${DEFAULT_USER}:${DEFAULT_USER}" | chpasswd
-  mkdir -p /home/${DEFAULT_USER}
-  chown ${DEFAULT_USER}:${DEFAULT_USER} /home/${DEFAULT_USER}
   addgroup ${DEFAULT_USER} staff
 
   mkdir -p /home/${DEFAULT_USER}/.rstudio/monitored/user-settings

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -5,7 +5,7 @@ if id -u "${user}" >/dev/null 2>&1; then
 else
   ## Need to configure non-root user for RStudio
   DEFAULT_USER=${1:-${DEFAULT_USER:-rstudio}}
-  useradd $DEFAULT_USER
+  useradd -s /bin/bash $DEFAULT_USER
   echo "${DEFAULT_USER}:${DEFAULT_USER}" | chpasswd
   mkdir -p /home/${DEFAULT_USER}
   chown ${DEFAULT_USER}:${DEFAULT_USER} /home/${DEFAULT_USER}


### PR DESCRIPTION
Currently, the shell for the `rocker/rstudio` default non-root user `rstudio` is bash on RStudio, but `/bin/sh` when logged in outside RStudio.
For many users, bash may be preferred as the login shell.

In addition, I changed the default user's home directory creation to be done with the `-m` option of the `useradd` command.