### PR TITLE
Add a script for generate docker-bake.json

### DIFF
--- a/bakefiles/README.md
+++ b/bakefiles/README.md
@@ -1,0 +1,3 @@
+# Build configuration files for the `docker buildx bake` command.
+
+:warning: JSON files in this directory are generated from the stack files by [`make-bakejson.R`](../build/make-bakejson.R). **Don't edit manually.** :warning:

--- a/bakefiles/README.md
+++ b/bakefiles/README.md
@@ -1,3 +1,3 @@
-# Build configuration files for the `docker buildx bake` command.
+# Build configuration files for the `docker buildx bake` command
 
 :warning: JSON files in this directory are generated from the stack files by [`make-bakejson.R`](../build/make-bakejson.R). **Don't edit manually.** :warning:

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -38,7 +38,7 @@ write_bakejson <- function(stack_file) {
 
 message("\nstart writing docker-bake.json files.")
 
-devnull <- list.files(path = "stacks", pattern = "\\.json$", full.names = TRUE) %>%
-  purrr::map(write_bakejson)
+list.files(path = "stacks", pattern = "\\.json$", full.names = TRUE) %>%
+  purrr::walk(write_bakejson)
 
 message("make-bakejson.R done!\n")

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -1,0 +1,44 @@
+#!/usr/bin/env Rscript
+
+library(jsonlite)
+library(dplyr, warn.conflicts = FALSE)
+library(tibble)
+library(purrr, warn.conflicts = FALSE)
+
+
+write_bakejson <- function(stack_file) {
+  output_path <- sub("^stacks/", "bakefiles/", stack_file) %>% {
+    sub(".json", ".docker-bake.json", .)
+  }
+
+  stack_content <- jsonlite::read_json(stack_file)
+
+  stack_tag <- stack_content$TAG
+
+  stack_content$stack %>%
+    tibble::enframe() %>%
+    dplyr::transmute(
+      name = purrr::map_chr(value, "IMAGE", .default = NA),
+      context = "./",
+      dockerfile = paste0("dockerfiles/Dockerfile_", name, "_", stack_tag),
+      tags = purrr::map(
+        value,
+        ~ dplyr::if_else(is.null(.x$tags), list(paste0("docker.io/rocker/", .x$IMAGE, ":", stack_tag)), .x$tags)
+      ),
+      platforms = purrr::map(value, "platforms", .default = list("linux/amd64"))
+    ) %>%
+    {
+      list(target = purrr::transpose(dplyr::select(., !name), .names = .$name))
+    } %>%
+    jsonlite::write_json(output_path, pretty = TRUE, auto_unbox = TRUE)
+
+  message(output_path)
+}
+
+
+message("\nstart writing docker-bake.json files.")
+
+devnull <- list.files(path = "stacks", pattern = "\\.json$", full.names = TRUE) %>%
+  purrr::map(write_bakejson)
+
+message("make-bakejson.R done!\n")

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -23,7 +23,7 @@ write_bakejson <- function(stack_file) {
       dockerfile = paste0("dockerfiles/Dockerfile_", name, "_", stack_tag),
       tags = purrr::map(
         value,
-        ~ dplyr::if_else(is.null(.x$tags), list(paste0("docker.io/rocker/", .x$IMAGE, ":", stack_tag)), .x$tags)
+        ~ if (!is.null(.x$tags)) .x$tags else list(paste0("docker.io/rocker/", .x$IMAGE, ":", stack_tag))
       ),
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64"))
     ) %>%

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -8,7 +8,7 @@ library(purrr, warn.conflicts = FALSE)
 
 write_bakejson <- function(stack_file) {
   output_path <- sub("^stacks/", "bakefiles/", stack_file) %>% {
-    sub(".json", ".docker-bake.json", .)
+    sub(".json$", ".docker-bake.json", .)
   }
 
   stack_content <- jsonlite::read_json(stack_file)


### PR DESCRIPTION
Suggested by #195

To be able to use `docker buildx bake` to build container images, I add a script `make-bakejson.R` that generates `docker-bake.json` from the stack files.
Unlike `docker-compose.yml`, `docker-bake.json` allows you to configure multiple tags and multiple platforms for a single target, allowing you to run multi-architecture builds with a simple command.
(At the moment, neither `tags` nor `platforms` exist in the stack files, so multiple tags and platforms will not be set in `docker-bake.json`.)

To build `rocker/rstudio:4.1.0` using `bakefiles/core-4.1.0.docker-bake.json`, generated from `stacks/core-4.1.0.json`, execute the following command:

```shell
$ docker buildx bake -f ./bakefiles/core-4.1.0.docker-bake.json rstudio
```

Note that unlike the `docker-compose build` command, the `buildx bake` command builds all targets in parallel, so we need to build images one by one to build images with dependencies.