### PR TITLE
Update the RStudio daily build file name regex

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -45,7 +45,7 @@ if [ -z "$RSTUDIO_VERSION_ARG" ] || [ "$RSTUDIO_VERSION_ARG" = "latest" ]; then
 elif [ "$RSTUDIO_VERSION_ARG" = "preview" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "daily" ]; then
-    DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)[0-9]\.[0-9]\.[0-9]+" | sort | tail -n 1)
+    DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)daily-[0-9]+-[0-9]+\.[0-9]\.[0-9]+" | sort | tail -n 1)
 else
     DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG}
 fi


### PR DESCRIPTION
The build of `rocker/rstudio:latest-daily` is failing for two days in a row, and the reason seems to be a change in the pattern of the file name of RStudio Server daily build.

It seems to be related to https://github.com/rstudio/rstudio/pull/9639

![image](https://user-images.githubusercontent.com/50911393/127479398-92c8b0fc-e962-47a5-80d0-5445de0415c9.png)
![image](https://user-images.githubusercontent.com/50911393/127479406-87080571-2771-4ec0-b054-5dd83d7a0931.png)

Current file name pattern.
![image](https://user-images.githubusercontent.com/50911393/127479514-29e3fe5e-15f7-4ddf-be4b-20489be38a31.png)
