### PR TITLE
Add reports generation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 *.Rproj
 .*.swp
+
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .*.swp
 
 tmp
+
+# Use for build reports
+/reports

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,12 @@ inspect-image/%:
 	-docker image inspect $(@F) > $(REPORT_SOURCE_ROOT)/$(@F)/docker_inspect.json
 	-docker run --rm -it $(@F) dpkg-query --show --showformat='$${Package}\t$${Version}\n' > $(REPORT_SOURCE_ROOT)/$(@F)/apt_packages.tsv
 	-docker run --rm -it $(@F) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_ROOT)/$(@F)/r_packages.ssv
+	-docker run --rm -it $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
 inspect-image-all: $(foreach I, $(shell docker image ls -q -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)"), inspect-image/$(I))
 
 REPORT_SOURCE_DIR ?= $(wildcard $(REPORT_SOURCE_ROOT)/*)
 report/%:
+	mkdir -p $(REPORT_DIR)
 	-./build/knit-report.R -d ../../$(REPORT_SOURCE_ROOT)/$(@F) $(@F) $(REPORT_DIR)
 report-all: $(foreach I, $(REPORT_SOURCE_DIR), report/$(I))
 

--- a/Makefile
+++ b/Makefile
@@ -59,21 +59,25 @@ $(PUSHES): %.push: %
 	./tag.sh $< $(LATEST_TAG)
 
 
-BUILT_IMAGES := $(shell docker image ls -q -f "label=org.opencontainers.image.source=https://github.com/rocker-org/rocker-versioned2")
-REPORT_SOURCE_DIR ?= tmp
+IMAGE_SOURCE ?= https://github.com/rocker-org/rocker-versioned2
+REPORT_SOURCE_ROOT ?= tmp
 REPORT_DIR ?= reports
 
-## Display the value. ex. print-BUILT_IMAGES
+## Display the value. ex. print-REPORT_SOURCE_DIR
 print-%:
 	@echo $* = $($*)
 
-.PHONY: inspect-images
+inspect-image/%:
+	mkdir -p $(REPORT_SOURCE_ROOT)/$(@F)
+	-docker image inspect $(@F) > $(REPORT_SOURCE_ROOT)/$(@F)/docker_inspect.json
+	-docker run --rm -it $(@F) dpkg-query --show --showformat='$${Package}\t$${Version}\n' > $(REPORT_SOURCE_ROOT)/$(@F)/apt_packages.tsv
+	-docker run --rm -it $(@F) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_ROOT)/$(@F)/r_packages.ssv
+inspect-image-all: $(foreach I, $(shell docker image ls -q -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)"), inspect-image/$(I))
 
-inspect-images:
-	$(foreach I, $(BUILT_IMAGES), $(shell mkdir -p $(REPORT_SOURCE_DIR)/$(I)))
-	$(foreach I, $(BUILT_IMAGES), $(shell docker image inspect $(I) > $(REPORT_SOURCE_DIR)/$(I)/docker_inspect.json))
-	$(foreach I, $(BUILT_IMAGES), $(shell docker run --rm -it $(I) dpkg-query --show --showformat='$${Package}\t$${Version}\n' > $(REPORT_SOURCE_DIR)/$(I)/apt_packages.tsv))
-	$(foreach I, $(BUILT_IMAGES), $(shell docker run --rm -it $(I) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_DIR)/$(I)/r_packages.ssv))
+REPORT_SOURCE_DIR ?= $(wildcard $(REPORT_SOURCE_ROOT)/*)
+report/%:
+	-./build/knit-report.R -d ../../$(REPORT_SOURCE_ROOT)/$(@F) $(@F) $(REPORT_DIR)
+report-all: $(foreach I, $(REPORT_SOURCE_DIR), report/$(I))
 
 clean:
 	rm -f dockerfiles/Dockerfile_* compose/*.yml bakefiles/*.json

--- a/build/knit-report.R
+++ b/build/knit-report.R
@@ -7,17 +7,18 @@ arguments <- "
 Generate a report of container image's infomation.
 
 Usage:
-  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] <image_name> <output_dir>
+  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] [-p <pip_file>] <image_name> <output_dir>
   knit-report.R [-d <directory_name>] <image_name> <output_dir>
 
 Options:
   -i --inspect    `docker instpect image` output file.
   -a --apt        `dpkg-query --show --showformat='${Package}\\t${Version}\\n'` output file.
   -r --R          `Rscript -e 'as.data.frame(installed.packages()[, 3])` output file.'
-  -d --directory  Directory, which contains source files, `docker_inspect.json`, `apt_packages.tsv`, `r_packages.ssv`.
+  -p --pip        `python3 -m pip list --disable-pip-version-check` output file.
+  -d --directory  Directory, which contains source files, `docker_inspect.json`, `apt_packages.tsv`, `r_packages.ssv`, `pip_packages.ssv`.
 
 Examples:
-  knit-report.R -i tmp/imageid/docker_inspect.json -a tmp/imageid/apt_packages.tsv -r tmp/imageid/r_packages.ssv imageid reports
+  knit-report.R -i tmp/imageid/docker_inspect.json -a tmp/imageid/apt_packages.tsv -r tmp/imageid/r_packages.ssv -p tmp/imageid/pip_packages.ssv imageid reports
   knit-report.R -d tmp/imageid imageid reports
 " |>
   docopt::docopt()
@@ -30,12 +31,14 @@ output_dir <- arguments$output_dir
 inspect_file <- arguments$inspect_file
 apt_file <- arguments$apt_file
 r_file <- arguments$r_file
+pip_file <- arguments$pip_file
 
-if(arguments$directory == TRUE) {
-  directory <- arguments$directory_name
-  inspect_file <- paste0(directory, "/docker_inspect.json")
-  apt_file <- paste0(directory, "/apt_packages.tsv")
-  r_file <- paste0(directory, "/r_packages.ssv")
+if (arguments$directory == TRUE) {
+  directory_name <- arguments$directory_name
+  inspect_file <- paste0(directory_name, "/docker_inspect.json")
+  apt_file <- paste0(directory_name, "/apt_packages.tsv")
+  r_file <- paste0(directory_name, "/r_packages.ssv")
+  pip_file <- paste0(directory_name, "/pip_packages.ssv")
 }
 
 rmarkdown::render(
@@ -46,6 +49,7 @@ rmarkdown::render(
     image_name = image_name,
     inspect_file = inspect_file,
     apt_file = apt_file,
-    r_file = r_file
+    r_file = r_file,
+    pip_file = pip_file
   )
 )

--- a/build/knit-report.R
+++ b/build/knit-report.R
@@ -1,0 +1,35 @@
+#!/usr/bin/env Rscript
+
+library(docopt)
+library(rmarkdown)
+
+arguments <- "
+Generate a report of container image's infomation.
+
+Usage:
+  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] <image_name>
+  knit-report.R <image_name>
+
+Options:
+  -i --inspect  `docker instpect image` output file.
+  -a --apt      `dpkg-query --show --showformat='${Package}\\t${Version}\\n'` output file.
+  -r --R        `Rscript -e 'as.data.frame(installed.packages()[, 3])` output file.'
+" |>
+  docopt::docopt()
+
+template <- "build/reports/template.Rmd"
+
+inspect_file <- arguments$inspect_file
+apt_file <- arguments$apt_file
+r_file <- arguments$r_file
+
+rmarkdown::render(
+  input = template,
+  output_file = paste0(arguments$image_name, ".md"),
+  params = list(
+    image_name = arguments$image_name,
+    inspect_file = inspect_file,
+    apt_file = apt_file,
+    r_file = r_file
+  )
+)

--- a/build/knit-report.R
+++ b/build/knit-report.R
@@ -7,27 +7,43 @@ arguments <- "
 Generate a report of container image's infomation.
 
 Usage:
-  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] <image_name>
-  knit-report.R <image_name>
+  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] <image_name> <output_dir>
+  knit-report.R [-d <directory_name>] <image_name> <output_dir>
 
 Options:
-  -i --inspect  `docker instpect image` output file.
-  -a --apt      `dpkg-query --show --showformat='${Package}\\t${Version}\\n'` output file.
-  -r --R        `Rscript -e 'as.data.frame(installed.packages()[, 3])` output file.'
+  -i --inspect    `docker instpect image` output file.
+  -a --apt        `dpkg-query --show --showformat='${Package}\\t${Version}\\n'` output file.
+  -r --R          `Rscript -e 'as.data.frame(installed.packages()[, 3])` output file.'
+  -d --directory  Directory, which contains source files, `docker_inspect.json`, `apt_packages.tsv`, `r_packages.ssv`.
+
+Examples:
+  knit-report.R -i tmp/imageid/docker_inspect.json -a tmp/imageid/apt_packages.tsv -r tmp/imageid/r_packages.ssv imageid reports
+  knit-report.R -d tmp/imageid imageid reports
 " |>
   docopt::docopt()
 
 template <- "build/reports/template.Rmd"
 
+image_name <- arguments$image_name
+output_dir <- arguments$output_dir
+
 inspect_file <- arguments$inspect_file
 apt_file <- arguments$apt_file
 r_file <- arguments$r_file
 
+if(arguments$directory == TRUE) {
+  directory <- arguments$directory_name
+  inspect_file <- paste0(directory, "/docker_inspect.json")
+  apt_file <- paste0(directory, "/apt_packages.tsv")
+  r_file <- paste0(directory, "/r_packages.ssv")
+}
+
 rmarkdown::render(
   input = template,
+  output_dir = output_dir,
   output_file = paste0(arguments$image_name, ".md"),
   params = list(
-    image_name = arguments$image_name,
+    image_name = image_name,
     inspect_file = inspect_file,
     apt_file = apt_file,
     r_file = r_file

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -10,6 +10,7 @@ params:
   inspect_file: ""
   apt_file: ""
   r_file: ""
+  pip_file: ""
 ---
 
 ```{r setup, include=FALSE}
@@ -26,12 +27,15 @@ jsonlite::read_json(params$inspect_file) |>
     RepoTags = purrr::map(value, "RepoTags"),
     RepoDigests = purrr::map_chr(value, list("RepoDigests", 1)),
     CreatedTime = purrr::map_chr(value, "Created"),
+    Size = purrr::map_dbl(value, "Size"),
     Env = purrr::map(value, c("ContainerConfig", "Env"))
   ) |>
+  tidyr::replace_na(list(RepoTags = list("None"))) |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),
     RepoTags = paste0("`", paste(unlist(RepoTags), collapse = "`, `"), "`"),
     RepoDigests = paste0("`", RepoDigests, "`"),
+    Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = paste(unlist(Env), collapse = ", ")
   ) |>
   tidyr::pivot_longer(cols = tidyselect::everything())
@@ -55,4 +59,17 @@ readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
     package = X1,
     version = X2
   )
+```
+
+## Python3 pip packages
+
+```{r}
+try(
+  readr::read_table(params$pip_file, skip = 2, col_names = FALSE) |>
+    dplyr::transmute(
+      package = X1,
+      version = X2
+    ),
+  silent = TRUE
+)
 ```

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -1,0 +1,58 @@
+---
+title: "`r params$image_name`"
+date: "`r format(Sys.time(), '%Y-%m-%d %H:%M:%S %Z')`"
+output:
+  github_document:
+    html_preview: false
+    df_print: kable
+params:
+  image_name: ""
+  inspect_file: ""
+  apt_file: ""
+  r_file: ""
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE, message = FALSE)
+```
+
+## Image info
+
+```{r}
+jsonlite::read_json(params$inspect_file) |>
+  tibble::enframe() |>
+  dplyr::transmute(
+    ImageID = purrr::map_chr(value, "Id"),
+    RepoTags = purrr::map(value, "RepoTags"),
+    RepoDigests = purrr::map_chr(value, list("RepoDigests", 1)),
+    CreatedTime = purrr::map_chr(value, "Created"),
+    Env = purrr::map(value, c("ContainerConfig", "Env"))
+  ) |>
+  dplyr::mutate(
+    ImageID = paste0("`", ImageID, "`"),
+    RepoTags = paste0("`", paste(unlist(RepoTags), collapse = "`, `"), "`"),
+    RepoDigests = paste0("`", RepoDigests, "`"),
+    Env = paste(unlist(Env), collapse = ", ")
+  ) |>
+  tidyr::pivot_longer(cols = tidyselect::everything())
+```
+
+## apt packages
+
+```{r}
+readr::read_tsv(params$apt_file, col_names = FALSE) |>
+  dplyr::transmute(
+    package = X1,
+    version = X2
+  )
+```
+
+## R packages
+
+```{r}
+readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
+  dplyr::transmute(
+    package = X1,
+    version = X2
+  )
+```

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -30,10 +30,13 @@ jsonlite::read_json(params$inspect_file) |>
     Size = purrr::map_dbl(value, "Size"),
     Env = purrr::map(value, c("ContainerConfig", "Env"))
   ) |>
-  tidyr::replace_na(list(RepoTags = list("None"))) |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),
-    RepoTags = paste0("`", paste(unlist(RepoTags), collapse = "`, `"), "`"),
+    RepoTags = dplyr::if_else(
+      !is.null(unlist(RepoTags)),
+      paste0("`", paste(unlist(RepoTags), collapse = "`, `"), "`"),
+      ""
+    ),
     RepoDigests = paste0("`", RepoDigests, "`"),
     Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = paste(unlist(Env), collapse = ", ")


### PR DESCRIPTION
Suggested by https://github.com/rocker-org/rocker-versioned2/issues/181#issuecomment-891075725

Add a script and a report template to create reports about the contents of the container images.
By publishing the generated Markdown files on GitHub (maybe on the wiki?), users will be able to go back and examine past images.

The report will look like this:

![image](https://user-images.githubusercontent.com/50911393/128210304-a01ece1b-337c-4065-8b36-dcc87df390d4.png)

To create reports, we will need files in `tmp` directory about the container images created by the following command. (need docker)

```shell
$ make inspect-image-all
```

Next, run the following command to generate reports in the `reports` directory. (need R 4.1 and the tidyverse packages etc., I run this command in `rocker/tidyverse:latest`)

```shell
$ make report-all
```

**ToDo**

- [x] Add jobs to the Makefile
- [x] Python packages list
- ~~commit hash~~ Cannot be implemented at this time because it is necessary to set [the `org.opencontainers.image.revision` annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) when building images. I would like to set this up after we change the build method to one using `buildx bake`. (#199)