### PR TITLE
added gpu test script and associated aws infrastructure code

### DIFF
--- a/tests/gpu/misc/Dockerfile
+++ b/tests/gpu/misc/Dockerfile
@@ -1,0 +1,18 @@
+FROM rocker/ml-gpu
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  cuda-samples-9-0 \
+  python3-dev \
+  python3-pip \
+  python3-venv
+
+RUN pip install --upgrade tensorflow
+
+WORKDIR /usr/local/cuda-9.0/samples
+RUN make
+
+COPY ./test-gpu.sh /test-gpu.sh
+RUN chmod +x /test-gpu.sh
+
+ENTRYPOINT ["tail"]
+CMD ["-f","/dev/null"]

--- a/tests/gpu/misc/deploy-aws-rocker-ml-gpu.yml
+++ b/tests/gpu/misc/deploy-aws-rocker-ml-gpu.yml
@@ -1,0 +1,68 @@
+---
+- hosts: rocker-server-aws
+  vars:
+  tasks:
+    - name: add docker gpg apt key
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+    - name: add docker repo
+      apt_repository:
+        repo: deb https://download.docker.com/linux/ubuntu bionic stable
+        state: present
+    - name: update apt and install docker-ce
+      apt: update_cache=yes name=docker-ce state=present
+    - name: add nvidia-docker apt key
+      apt_key:
+        url: https://nvidia.github.io/nvidia-docker/gpgkey
+        state: present
+    - name: copy nvidia-docker.list
+      get_url:
+        url: https://nvidia.github.io/nvidia-docker/ubuntu20.04/nvidia-docker.list
+        dest: /etc/apt/sources.list.d/nvidia-docker.list
+    - name: install system packages
+      apt:
+        name:
+          - python3-pip
+          - python3-setuptools
+          - nvidia-docker2
+          - nvidia-driver-470
+        state: present
+        update_cache: yes
+    - name: install Docker module for Python
+      pip:
+        name:
+          - docker
+          - docker-compose
+    - name: restart docker daemon
+      command: systemctl restart docker
+    - name: reboot instance so graphics driver is active
+      reboot:
+    - name: copy files to instance
+      copy:
+        src: "./{{ item }}"
+        dest: /root
+      become: yes
+      loop:
+        - "Dockerfile"
+        - "docker-compose.yml"
+        - "test-gpu.sh"
+    - name: build docker image
+      become: yes
+      docker_image:
+        name: test-1
+        build:
+          path: /root
+          nocache: yes
+        source: build
+    - name: run docker image
+      become: yes
+      docker_service:
+        project_src: /root
+        build:  yes
+
+##### manual steps required:
+# 1) run test script
+
+# bugs
+# in 'copy nvidia-docker.list we need to get ubuntu20.04 from env vars not my hardcoding

--- a/tests/gpu/misc/docker-compose.yml
+++ b/tests/gpu/misc/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  rocker:
+    image: rocker
+    build:
+      context: .
+      dockerfile: "Dockerfile"
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - capabilities: [gpu]

--- a/tests/gpu/misc/hosts
+++ b/tests/gpu/misc/hosts
@@ -1,0 +1,2 @@
+[rocker-server-aws]
+18.207.200.27 ansible_ssh_private_key_file=rocker-gpu.pem ansible_ssh_user=ubuntu

--- a/tests/gpu/test-gpu.sh
+++ b/tests/gpu/test-gpu.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# This script tests for gpu fuctionality
+
+# first check for proc file for driver version
+
+echo "checking for driver version file..."
+PROC_DRIVER_FILE=/proc/driver/nvidia/version
+if [ -f "$PROC_DRIVER_FILE" ]
+then
+  echo "driver version file found. Contents:"
+  cat $PROC_DRIVER_FILE
+else
+  echo "$PROC_DRIVER_FILE doesn't exist"
+  echo "WARNING: Nvidia CUDA driver may not be correctly installed."
+fi
+
+# check for driver and gpu info from nvida-smi
+
+printf "\nchecking for driver and gpu info from nvidia-smi...\n"
+DRIVER_CHECK_OUTPUT=$(nvidia-smi 2>&1)
+if [ $? -ne 0 ]
+then
+  echo "failed to run nvidia-smi with error message: $DRIVER_CHECK_OUTPUT"
+  echo "WARNING: Nvidia CUDA driver may not be correctly installed."
+else
+  echo "driver and gpu information from from nvidia-smi:"
+  # running again because output format removed in variable
+  nvidia-smi
+fi
+
+# check CUDA Toolkit version with nvcc -V
+printf "\nchecking for CUDA Toolkit by running: nvcc -V...\n"
+TOOLKIT_CHECK_OUTPUT=$(nvcc -V 2>&1)
+if [ $? -ne 0 ]
+then
+  echo "Failed to run 'nvcc -V' with error message: $TOOLKIT_CHECK_OUTPUT"
+  echo "WARNING: CUDA toolkit may not be correctly installed."
+else
+  echo "toolkit information from 'nvcc -V':"
+  echo $TOOLKIT_CHECK_OUTPUT
+fi
+
+# run tests from CUDA samples
+printf "\nchecking for CUDA Samples...\n"
+DPKG_QUERY_SAMPLES=$(dpkg-query -l cuda-samples-9-0 2>&1)
+if [ $? -ne 0 ]
+then
+  echo "CUDA samples not installed. Please install for additional tests."
+else
+  echo "CUDA samples installed. Running sample code tests..."
+
+  # run deviceQuery
+  printf "\ntesting deviceQuery...\n"
+  DEVICE_QUERY_OUTPUT=$(/usr/local/cuda-9.0/samples/1_Utilities/deviceQuery/deviceQuery 2>&1)
+  if [ $? -ne 0 ]
+  then
+    echo "deviceQuery failed with error message: $DEVICE_QUERY_OUTPUT"
+  else
+    echo "deviceQuery ran with output: $DEVICE_QUERY_OUTPUT"
+  fi
+
+  # run bandwidthTest
+  printf "\nrunning bandwidthTest...\n"
+  BANDWIDTH_TEST_OUTPUT=$(/usr/local/cuda-9.0/samples/1_Utilities/bandwidthTest/bandwidthTest 2>&1)
+  if [ $? -ne 0 ]
+  then
+    echo "bandwidthTest failed error message: $BANDWIDTH_TEST_OUTPUT"
+  else
+    echo "bandwidthTest ran with output: $BANDWIDTH_TEST_OUTPUT"
+  fi
+
+  # run matrixMulCUBLAS
+  printf "\nrunning matrixMulCUBLAS...\n"
+  SIMPLECUBLAS_OUTPUT=$(/usr/local/cuda-9.0/samples/7_CUDALibraries/simpleCUBLAS/simpleCUBLAS 2>&1)
+  if [ $? -ne 0 ]
+  then
+    echo "simpleCUBLAS failed with error message: $SIMPLECUBLAS_OUTPUT"
+  else
+    echo "simpleCUBLAS ran with output: $SIMPLECUBLAS_OUTPUT"
+  fi
+fi
+
+# check for tensorflow
+printf "\nchecking for tensorflow install...\n"
+TENSORFLOW_TEST_OUTPUT=$(python -c "import tensorflow as tf;print(tf.reduce_sum(tf.random.normal([1000, 1000])))" 2>&1)
+if [ $? -ne 0 ]
+then
+  echo "tensorflow failed with error: $TENSORFLOW_TEST_OUTPUT"
+else
+  echo "tensorflow installed"
+fi
+


### PR DESCRIPTION
Just submitting this PR to start the conversation about adding gpu testing infrastructure to the repo.

I'm submitting a bash script that tests for some basic gpu functionality and have included code I use to spin up an AWS gpu enabled instance for testing.
  
PR contains the following files:
tests/gpu/test-gpu.sh - bash script that checks for gpu functionality like: valid gpu driver, gpu toolkit, CUBLAS and tensorflow.
tests/gpu/misc - contains code I use for spinning up a rocker container on a gpu enabled AWS instance:
tests/gpu/misc/deploy-aws-rocker-ml-gpu.yml - Ansible playbook that installs CUDA driver on instance and builds Rocker container with Rocker image, CUDA samples & tensorflow installed.
tests/gpu/misc/Dockerfile - Dockerfile for build
tests/gpu/misc/docker-compose.yml - docker-compose file for building and running container with gpu support
tests/gpu/misc/hosts - hosts file for Ansible playbook

There are lots more applications in the CUDA samples that could be included in the test script, so please let me know if any seem helpful. 

I was planning to build this out to test for more drivers and toolkit versions and eventually more cards if that sounds good.  Please let me know if you have ideas about how I should proceed.

Please let me know any thoughts or suggestions.  Thanks!

Cheers,
Rob