### PR TITLE
Publish build reports to the wiki

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -35,7 +35,7 @@ jobs:
     needs: generate_matrix
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
           docker image push rocker/ml-verse:latest
       - name: Inspect built image
         run: |
-          make inspect-image-all
+          IMAGELIST_NAME=${{ matrix.r_version }}.tsv make inspect-image-all
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -90,8 +90,11 @@ jobs:
           path: tmp
 
   publish_reports:
-    needs: build
+    needs: [generate_matrix, build]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     container:
       image: rocker/tidyverse:latest
     steps:
@@ -107,9 +110,10 @@ jobs:
         with:
           name: tmp
           path: tmp
-      - name: Generate reports
+      - name: Generate reports and update wiki home
         run: |
           make report-all
+          IMAGELIST_NAME=${{ matrix.r_version }}.tsv make wiki-home
       - name: Update wiki
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -112,4 +112,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Automated update
-          repository: wiki
+          repository: reports

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          name: tmp
           path: tmp
 
   publish_reports:
@@ -104,6 +105,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
+          name: tmp
           path: tmp
       - name: Generate reports
         run: |

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,11 +90,8 @@ jobs:
           path: tmp
 
   publish_reports:
-    needs: [generate_matrix, build]
+    needs: build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     container:
       image: rocker/tidyverse:latest
     steps:
@@ -113,7 +110,7 @@ jobs:
       - name: Generate reports and update wiki home
         run: |
           make report-all
-          IMAGELIST_NAME=${{ matrix.r_version }}.tsv make wiki-home
+          make wiki-home
       - name: Update wiki
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,6 +90,7 @@ jobs:
           path: tmp
 
   publish_reports:
+    if: always()
     needs: build
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -80,3 +80,36 @@ jobs:
           docker image push rocker/binder:latest
           docker image push rocker/ml:latest
           docker image push rocker/ml-verse:latest
+      - name: Inspect built image
+        run: |
+          make inspect-image-all
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: tmp
+
+  publish_reports:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+      - name: Checkout wiki
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ github.repository }}.wiki"
+          path: reports
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: tmp
+      - name: Generate reports
+        run: |
+          make report-all
+      - name: Update wiki
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automated update
+          repository: wiki

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,9 @@ print-%:
 inspect-image/%:
 	mkdir -p $(REPORT_SOURCE_ROOT)/$(@F)
 	-docker image inspect $(@F) > $(REPORT_SOURCE_ROOT)/$(@F)/docker_inspect.json
-	-docker run --rm -it $(@F) dpkg-query --show --showformat='$${Package}\t$${Version}\n' > $(REPORT_SOURCE_ROOT)/$(@F)/apt_packages.tsv
-	-docker run --rm -it $(@F) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_ROOT)/$(@F)/r_packages.ssv
-	-docker run --rm -it $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
+	-docker run --rm $(@F) dpkg-query --show --showformat='$${Package}\t$${Version}\n' > $(REPORT_SOURCE_ROOT)/$(@F)/apt_packages.tsv
+	-docker run --rm $(@F) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_ROOT)/$(@F)/r_packages.ssv
+	-docker run --rm $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
 inspect-image-all: $(foreach I, $(shell docker image ls -q -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)"), inspect-image/$(I))
 
 REPORT_SOURCE_DIR := $(wildcard $(REPORT_SOURCE_ROOT)/*)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ $(PUSHES): %.push: %
 
 
 IMAGE_SOURCE ?= https://github.com/rocker-org/rocker-versioned2
-REPORT_SOURCE_ROOT ?= tmp
+REPORT_SOURCE_ROOT ?= tmp/inspects
 REPORT_DIR ?= reports
 
 ## Display the value. ex. print-REPORT_SOURCE_DIR
@@ -75,7 +75,7 @@ inspect-image/%:
 	-docker run --rm -it $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
 inspect-image-all: $(foreach I, $(shell docker image ls -q -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)"), inspect-image/$(I))
 
-REPORT_SOURCE_DIR ?= $(wildcard $(REPORT_SOURCE_ROOT)/*)
+REPORT_SOURCE_DIR := $(wildcard $(REPORT_SOURCE_ROOT)/*)
 report/%:
 	mkdir -p $(REPORT_DIR)
 	-./build/knit-report.R -d ../../$(REPORT_SOURCE_ROOT)/$(@F) $(@F) $(REPORT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ report-all: $(foreach I, $(REPORT_SOURCE_DIR), report/$(I))
 # Move image list to wiki and update Home.md
 wiki-home:
 	cp -r $(IMAGELIST_DIR) $(REPORT_DIR)
-	-Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "reports", output_file = "Home.md")'
+	-Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "$(REPORT_DIR)", output_file = "Home.md")'
 
 clean:
 	rm -f dockerfiles/Dockerfile_* compose/*.yml bakefiles/*.json

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ $(PUSHES): %.push: %
 
 IMAGE_SOURCE ?= https://github.com/rocker-org/rocker-versioned2
 REPORT_SOURCE_ROOT ?= tmp/inspects
+IMAGELIST_DIR ?= tmp/imagelist
+IMAGELIST_NAME ?= imagelist.tsv
 REPORT_DIR ?= reports
 
 ## Display the value. ex. print-REPORT_SOURCE_DIR
@@ -74,12 +76,19 @@ inspect-image/%:
 	-docker run --rm $(@F) Rscript -e 'as.data.frame(installed.packages()[, 3])' > $(REPORT_SOURCE_ROOT)/$(@F)/r_packages.ssv
 	-docker run --rm $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
 inspect-image-all: $(foreach I, $(shell docker image ls -q -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)"), inspect-image/$(I))
+	mkdir -p $(IMAGELIST_DIR)
+	docker image ls -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)" --format "{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.CreatedAt}}" > $(IMAGELIST_DIR)/$(IMAGELIST_NAME)
 
 REPORT_SOURCE_DIR := $(wildcard $(REPORT_SOURCE_ROOT)/*)
 report/%:
 	mkdir -p $(REPORT_DIR)
 	-./build/knit-report.R -d ../../$(REPORT_SOURCE_ROOT)/$(@F) $(@F) $(REPORT_DIR)
 report-all: $(foreach I, $(REPORT_SOURCE_DIR), report/$(I))
+
+# Move image list to wiki and update Home.md
+wiki-home:
+	cp -r $(IMAGELIST_DIR) $(REPORT_DIR)
+	Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "reports", output_file = "Home.md")'
 
 clean:
 	rm -f dockerfiles/Dockerfile_* compose/*.yml bakefiles/*.json

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ report-all: $(foreach I, $(REPORT_SOURCE_DIR), report/$(I))
 # Move image list to wiki and update Home.md
 wiki-home:
 	cp -r $(IMAGELIST_DIR) $(REPORT_DIR)
-	Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "reports", output_file = "Home.md")'
+	-Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "reports", output_file = "Home.md")'
 
 clean:
 	rm -f dockerfiles/Dockerfile_* compose/*.yml bakefiles/*.json

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -49,10 +49,12 @@ jsonlite::read_json(params$inspect_file) |>
   dplyr::transmute(
     ImageID = purrr::map_chr(value, "Id"),
     RepoTags = purrr::map(value, "RepoTags"),
-    RepoDigests = purrr::map(value, list("RepoDigests")),
-    CreatedTime = purrr::map_chr(value, "Created"),
-    Size = purrr::map_dbl(value, "Size"),
-    Env = purrr::map(value, c("ContainerConfig", "Env"))
+    RepoDigests = purrr::map(value, "RepoDigests"),
+    ImageSource = purrr::map_chr(value, c("Config", "Labels", "org.opencontainers.image.source"), .default = NA_character_),
+    ImageRevision = purrr::map_chr(value, c("Config", "Labels", "org.opencontainers.image.revision"), .default = NA_character_),
+    CreatedTime = purrr::map_chr(value, "Created", .default = NA_character_),
+    Size = purrr::map_dbl(value, "Size", .default = NA_real_),
+    Env = purrr::map(value, c("Config", "Env"))
   ) |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -3,8 +3,9 @@ title: "`r params$image_name`"
 date: "`r format(Sys.time(), '%Y-%m-%d %H:%M:%S %Z')`"
 output:
   github_document:
-    html_preview: false
+    toc: true
     df_print: kable
+    html_preview: false
 params:
   image_name: ""
   inspect_file: ""
@@ -17,27 +18,46 @@ params:
 knitr::opts_chunk$set(echo = FALSE, message = FALSE)
 ```
 
+```{r}
+.link_to_commit <- function(commit_hash) {
+  base_url <- "https://github.com/rocker-org/rocker-versioned2/tree/"
+  commit_short_hash <- commit_hash |>
+    substr(1, 7)
+  linked_text <- paste0("[`", commit_short_hash, "`](", base_url, commit_hash, ")")
+
+  return(linked_text)
+}
+```
+
+*This report was generated from `r system("git rev-parse HEAD", intern = TRUE) |> .link_to_commit()`.*
+
 ## Image info
 
 ```{r}
+.unlist_and_enclose <- function(x) {
+  chr <- dplyr::if_else(
+    !is.null(unlist(x)),
+    paste0("`", paste(unlist(x), collapse = "`, `"), "`"),
+    ""
+  )
+
+  return(chr)
+}
+
 jsonlite::read_json(params$inspect_file) |>
   tibble::enframe() |>
   dplyr::transmute(
     ImageID = purrr::map_chr(value, "Id"),
     RepoTags = purrr::map(value, "RepoTags"),
-    RepoDigests = purrr::map_chr(value, list("RepoDigests", 1)),
+    RepoDigests = purrr::map(value, list("RepoDigests")),
     CreatedTime = purrr::map_chr(value, "Created"),
     Size = purrr::map_dbl(value, "Size"),
     Env = purrr::map(value, c("ContainerConfig", "Env"))
   ) |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),
-    RepoTags = dplyr::if_else(
-      !is.null(unlist(RepoTags)),
-      paste0("`", paste(unlist(RepoTags), collapse = "`, `"), "`"),
-      ""
-    ),
-    RepoDigests = paste0("`", RepoDigests, "`"),
+    RepoTags = .unlist_and_enclose(RepoTags),
+    RepoDigests = .unlist_and_enclose(RepoDigests),
     Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = paste(unlist(Env), collapse = ", ")
   ) |>

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -64,7 +64,9 @@ jsonlite::read_json(params$inspect_file) |>
   tidyr::pivot_longer(cols = tidyselect::everything())
 ```
 
-## apt packages
+## Installed packages
+
+### apt packages
 
 ```{r}
 readr::read_tsv(params$apt_file, col_names = FALSE) |>
@@ -74,7 +76,7 @@ readr::read_tsv(params$apt_file, col_names = FALSE) |>
   )
 ```
 
-## R packages
+### R packages
 
 ```{r}
 readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
@@ -84,7 +86,7 @@ readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
   )
 ```
 
-## Python3 pip packages
+### Python3 pip packages
 
 ```{r}
 try(

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -31,7 +31,7 @@ library(lubridate)
 ```
 
 This wiki contains information about images built from this repository by GitHub Actions and published to DockerHub.  
-For more general information about Rocker Project, check out [the rocker-org/rocker repository's wiki](https://github.com/rocker-org/rocker/wiki) and [the Rocker Project website](https://www.rocker-project.org/).
+For more general information about the Rocker Project, check out [the rocker-org/rocker repository's wiki](https://github.com/rocker-org/rocker/wiki) and [the Rocker Project website](https://www.rocker-project.org/).
 
 *This page was generated from `r system("git rev-parse HEAD", intern = TRUE) |> .link_to_commit()`.*
 
@@ -43,11 +43,11 @@ Click on the ID to see detailed information about each image.
 ```{r}
 repos <- paste0(
   "rocker/",
-  c("r-ver", "rstudio", "tidyverse", "verse", "geospatial", "shiny", "shiny-verse", "ml", "ml-verse")
+  c("r-ver", "rstudio", "tidyverse", "verse", "geospatial", "shiny", "shiny-verse", "binder", "ml", "ml-verse")
 ) |>
   forcats::as_factor()
 
-df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*tsv") |>
+df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*.tsv") |>
   readr::read_tsv(col_names = FALSE) |>
   dplyr::transmute(
     id = X1,

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -54,7 +54,7 @@ df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*tsv") |>
     tag = X3,
     CreatedTime = lubridate::as_datetime(X4, format = "%Y-%m-%d %H:%M:%S")
   ) |>
-  dplyr::filter(tag != "<none>" & repo %in% repos)
+  dplyr::filter(tag != "<none>")
 
 df_tags <- df_all |>
   dplyr::mutate(repo_tags = paste0(repo, ":", tag)) |>
@@ -67,7 +67,7 @@ df_tags <- df_all |>
   )
 
 df_all |>
-  dplyr::filter(stringr::str_detect(tag, "^\\d\\.\\d\\.\\d$")) |>
+  dplyr::filter(repo %in% repos & stringr::str_detect(tag, "^\\d\\.\\d\\.\\d$")) |>
   dplyr::group_by(repo, tag) |>
   dplyr::slice_max(order_by = CreatedTime) |>
   dplyr::ungroup() |>

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -16,6 +16,7 @@ library(dplyr)
 library(readr)
 library(forcats)
 library(stringr)
+library(lubridate)
 ```
 
 ```{r}
@@ -52,15 +53,16 @@ df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*tsv") |>
     id = X1,
     repo = X2,
     tag = X3,
-    CreatedTime = lubridate::as_datetime(X4, format = "%Y-%m-%d %H:%M:%S")
+    CreatedTime = lubridate::ymd_hms(X4)
   ) |>
-  dplyr::filter(tag != "<none>")
+  dplyr::filter(tag != "<none>") |>
+  dplyr::distinct(id, repo, tag, .keep_all = TRUE)
 
 df_tags <- df_all |>
   dplyr::mutate(repo_tags = paste0(repo, ":", tag)) |>
   dplyr::arrange(desc(repo_tags)) |>
   dplyr::group_by(id) |>
-  dplyr::summarise(repo_tags = paste0(repo_tags, collapse = "`, `"), .groups = "drop") |>
+  dplyr::summarise(repo_tags = paste0(repo_tags, collapse = "`<br/>`"), .groups = "drop") |>
   dplyr::transmute(
     id,
     RepoTags = paste0("`", repo_tags, "`")

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -1,0 +1,83 @@
+---
+title: "History of published images"
+date: "`r format(Sys.time(), '%Y-%m-%d %H:%M:%S %Z')`"
+output:
+  github_document:
+    toc: false
+    df_print: kable
+    html_preview: false
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE, message = FALSE)
+
+library(fs)
+library(dplyr)
+library(readr)
+library(forcats)
+library(stringr)
+```
+
+```{r}
+.link_to_commit <- function(commit_hash) {
+  base_url <- "https://github.com/rocker-org/rocker-versioned2/tree/"
+  commit_short_hash <- commit_hash |>
+    substr(1, 7)
+  linked_text <- paste0("[`", commit_short_hash, "`](", base_url, commit_hash, ")")
+
+  return(linked_text)
+}
+```
+
+This wiki contains information about images built from this repository by GitHub Actions and published to DockerHub.  
+For more general information about Rocker Project, check out [the rocker-org/rocker repository's wiki](https://github.com/rocker-org/rocker/wiki) and [the Rocker Project website](https://www.rocker-project.org/).
+
+*This page was generated from `r system("git rev-parse HEAD", intern = TRUE) |> .link_to_commit()`.*
+
+## Tagged images
+
+The currently tagged images are as follows.  
+Click on the ID to see detailed information about each image.
+
+```{r}
+repos <- paste0(
+  "rocker/",
+  c("r-ver", "rstudio", "tidyverse", "verse", "geospatial", "shiny", "shiny-verse", "ml", "ml-verse")
+) |>
+  forcats::as_factor()
+
+df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*tsv") |>
+  readr::read_tsv(col_names = FALSE) |>
+  dplyr::transmute(
+    id = X1,
+    repo = X2,
+    tag = X3,
+    CreatedTime = lubridate::as_datetime(X4, format = "%Y-%m-%d %H:%M:%S")
+  ) |>
+  dplyr::filter(tag != "<none>" & repo %in% repos)
+
+df_tags <- df_all |>
+  dplyr::mutate(repo_tags = paste0(repo, ":", tag)) |>
+  dplyr::arrange(desc(repo_tags)) |>
+  dplyr::group_by(id) |>
+  dplyr::summarise(repo_tags = paste0(repo_tags, collapse = "`, `"), .groups = "drop") |>
+  dplyr::transmute(
+    id,
+    RepoTags = paste0("`", repo_tags, "`")
+  )
+
+df_all |>
+  dplyr::filter(stringr::str_detect(tag, "^\\d\\.\\d\\.\\d$")) |>
+  dplyr::group_by(repo, tag) |>
+  dplyr::slice_max(order_by = CreatedTime) |>
+  dplyr::ungroup() |>
+  dplyr::left_join(df_tags, by = "id") |>
+  dplyr::arrange(desc(tag), match(repo, repos)) |>
+  dplyr::transmute(
+    R = tag,
+    ImageName = paste0("[`", repo, "`](https://hub.docker.com/r/", repo, ")"),
+    RepoTags,
+    ID = paste0("[`", id, "`](https://github.com/rocker-org/rocker-versioned2/wiki/", id, ")"),
+    CreatedTime
+  )
+```


### PR DESCRIPTION
This PR is a continuation of #206 and was motivated by https://github.com/rocker-org/rocker-versioned2/issues/181#issuecomment-891075725.

Automatically publish reports on the Wiki after the container image build and update the Wiki's Home.
We will be able to find out what packages are included in every image that is built, and it will be easier to reuse old images.

Please activate the Wiki when merging this PR.

## How file generation works?

![image](https://user-images.githubusercontent.com/50911393/128605638-4c5a9308-82cd-4f73-994c-4c99f940be96.png)

The individual reports are as described in https://github.com/rocker-org/rocker-versioned2/pull/206#issuecomment-894333827.

The HOME of the Wiki is generated by the newly added RMarkdown file and Makefile jobs in this PR. (`make wiki-home`)
The wiki repository stores tsv files with names specific to each build workflow and each R version, and when `Home.md` is generated, all tsv files are read and the image list is updated.
We can trace the past images by checking the commit history in `Home.md`.

![image](https://user-images.githubusercontent.com/50911393/128605692-fb3f7c7e-6199-4242-a7c1-e4e7c107d33d.png)

## Appearance of the generated pages

### Wiki Home

![image](https://user-images.githubusercontent.com/50911393/128619304-f3bcb806-d4bb-4b62-b32f-fcb92e194a56.png)

### Reports

![image](https://user-images.githubusercontent.com/50911393/128626276-ab831d9d-4253-4561-bea4-4772abd296f8.png)

## ToDo

- [x] Test for GitHub Actions on fork
  - [x] Publish reports to the wiki after image build.
  - [x] Update the wiki's Home.
- [x] New job to update `Home.md`