### PR TITLE
move the position of the TAG key for `make-bakejson.R`

### DIFF
--- a/stacks/binder-4.0.0.json
+++ b/stacks/binder-4.0.0.json
@@ -1,18 +1,21 @@
 {
-"ordered": false,
+  "ordered": false,
+  "TAG": "4.0.0",
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
-"stack": [
-{
-    "IMAGE": "binder",
-    "TAG": "4.0.0",
-    "FROM": "rocker/geospatial:4.0.0",
-    "ENV": {
-      "NB_USER": "rstudio"
-           },
-    "RUN": ["/rocker_scripts/install_python.sh", "/rocker_scripts/install_binder.sh"],
-    "USER": "${NB_USER}",
-    "WORKDIR": "/home/${NB_USER}",
-    "CMD": "jupyter notebook --ip 0.0.0.0"
-}
-]
+  "stack": [
+    {
+      "IMAGE": "binder",
+      "FROM": "rocker/geospatial:4.0.0",
+      "ENV": {
+        "NB_USER": "rstudio"
+      },
+      "RUN": [
+        "/rocker_scripts/install_python.sh",
+        "/rocker_scripts/install_binder.sh"
+      ],
+      "USER": "${NB_USER}",
+      "WORKDIR": "/home/${NB_USER}",
+      "CMD": "jupyter notebook --ip 0.0.0.0"
+    }
+  ]
 }

--- a/stacks/binder-4.0.1.json
+++ b/stacks/binder-4.0.1.json
@@ -1,18 +1,21 @@
 {
-"ordered": false,
+  "ordered": false,
+  "TAG": "4.0.1",
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
-"stack": [
-{
-    "IMAGE": "binder",
-    "TAG": "4.0.1",
-    "FROM": "rocker/geospatial:4.0.1",
-    "ENV": {
-      "NB_USER": "rstudio"
-           },
-    "RUN": ["/rocker_scripts/install_python.sh", "/rocker_scripts/install_binder.sh"],
-    "USER": "${NB_USER}",
-    "WORKDIR": "/home/${NB_USER}",
-    "CMD": "jupyter notebook --ip 0.0.0.0"
-
-}]
+  "stack": [
+    {
+      "IMAGE": "binder",
+      "FROM": "rocker/geospatial:4.0.1",
+      "ENV": {
+        "NB_USER": "rstudio"
+      },
+      "RUN": [
+        "/rocker_scripts/install_python.sh",
+        "/rocker_scripts/install_binder.sh"
+      ],
+      "USER": "${NB_USER}",
+      "WORKDIR": "/home/${NB_USER}",
+      "CMD": "jupyter notebook --ip 0.0.0.0"
+    }
+  ]
 }

--- a/stacks/binder-4.0.2.json
+++ b/stacks/binder-4.0.2.json
@@ -1,18 +1,21 @@
 {
-"ordered": false,
+  "ordered": false,
+  "TAG": "4.0.2",
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
-"stack": [
-{
-    "IMAGE": "binder",
-    "TAG": "4.0.2",
-    "FROM": "rocker/geospatial:4.0.2",
-    "ENV": {
-      "NB_USER": "rstudio"
-           },
-    "RUN": ["/rocker_scripts/install_python.sh", "/rocker_scripts/install_binder.sh"],
-    "USER": "${NB_USER}",
-    "WORKDIR": "/home/${NB_USER}",
-    "CMD": "jupyter notebook --ip 0.0.0.0"
-
-}]
+  "stack": [
+    {
+      "IMAGE": "binder",
+      "FROM": "rocker/geospatial:4.0.2",
+      "ENV": {
+        "NB_USER": "rstudio"
+      },
+      "RUN": [
+        "/rocker_scripts/install_python.sh",
+        "/rocker_scripts/install_binder.sh"
+      ],
+      "USER": "${NB_USER}",
+      "WORKDIR": "/home/${NB_USER}",
+      "CMD": "jupyter notebook --ip 0.0.0.0"
+    }
+  ]
 }

--- a/stacks/binder-4.0.3.json
+++ b/stacks/binder-4.0.3.json
@@ -1,18 +1,21 @@
 {
-"ordered": false,
+  "ordered": false,
+  "TAG": "4.0.3",
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
-"stack": [
-{
-    "IMAGE": "binder",
-    "TAG": "4.0.3",
-    "FROM": "rocker/geospatial:4.0.3",
-    "ENV": {
-      "NB_USER": "rstudio"
-           },
-    "RUN": ["/rocker_scripts/install_python.sh", "/rocker_scripts/install_binder.sh"],
-    "USER": "${NB_USER}",
-    "WORKDIR": "/home/${NB_USER}",
-    "CMD": "jupyter notebook --ip 0.0.0.0"
-
-}]
+  "stack": [
+    {
+      "IMAGE": "binder",
+      "FROM": "rocker/geospatial:4.0.3",
+      "ENV": {
+        "NB_USER": "rstudio"
+      },
+      "RUN": [
+        "/rocker_scripts/install_python.sh",
+        "/rocker_scripts/install_binder.sh"
+      ],
+      "USER": "${NB_USER}",
+      "WORKDIR": "/home/${NB_USER}",
+      "CMD": "jupyter notebook --ip 0.0.0.0"
+    }
+  ]
 }

--- a/stacks/binder-4.0.4.json
+++ b/stacks/binder-4.0.4.json
@@ -1,18 +1,21 @@
 {
-"ordered": false,
+  "ordered": false,
+  "TAG": "4.0.4",
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
-"stack": [
-{
-    "IMAGE": "binder",
-    "TAG": "4.0.4",
-    "FROM": "rocker/geospatial:4.0.4",
-    "ENV": {
-      "NB_USER": "rstudio"
-           },
-    "RUN": ["/rocker_scripts/install_python.sh", "/rocker_scripts/install_binder.sh"],
-    "USER": "${NB_USER}",
-    "WORKDIR": "/home/${NB_USER}",
-    "CMD": "jupyter notebook --ip 0.0.0.0"
-
-}]
+  "stack": [
+    {
+      "IMAGE": "binder",
+      "FROM": "rocker/geospatial:4.0.4",
+      "ENV": {
+        "NB_USER": "rstudio"
+      },
+      "RUN": [
+        "/rocker_scripts/install_python.sh",
+        "/rocker_scripts/install_binder.sh"
+      ],
+      "USER": "${NB_USER}",
+      "WORKDIR": "/home/${NB_USER}",
+      "CMD": "jupyter notebook --ip 0.0.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
I missed about the old version of binder in #212.
Modify the format of `stacks/binder-4.0.0.json` - `stacks/binder-4.0.4.json` to be the same as the other stack files.

This change does not affect dockerfiles and compose files.