### PR TITLE
Add new workflow to generate reports on all tagged images

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "master"
     paths:
-      - "build/matrix/**"
+      - "build/matrix/latest.json"
       - "scripts/**"
       - "dockerfiles/Dockerfile_r-ver_*"
       - "dockerfiles/Dockerfile_rstudio_*"

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -29,6 +29,9 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
+      - name: Clean up
+        run: |
+          docker image prune --all --force
       - name: Pull images
         run: |
           BAKE_JSON=bakefiles/${{ matrix.r_version }}.docker-bake.json make pull-image-all

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,71 @@
+name: Report published images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-json
+        run: |
+          JSON=build/matrix/all.json
+          echo ::set-output name=json::${JSON}
+          echo ${JSON}
+      - id: set-matrix
+        run: |
+          CONTENT=$(jq -r 'tostring' ${{ steps.set-json.outputs.json }})
+          echo ::set-output name=matrix::${CONTENT}
+          echo ${CONTENT}
+
+  inspect:
+    needs: generate_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull images
+        run: |
+          BAKE_JSON=bakefiles/${{ matrix.r_version }}.docker-bake.json make pull-image-all
+      - name: Inspect built image
+        run: |
+          IMAGELIST_NAME=${{ matrix.r_version }}.tsv IMAGE_FILTER= make inspect-image-all
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: tmp
+          path: tmp
+
+  publish_reports:
+    if: always()
+    needs: inspect
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+      - name: Checkout wiki
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ github.repository }}.wiki"
+          path: reports
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: tmp
+          path: tmp
+      - name: Generate reports and update wiki home
+        run: |
+          make report-all
+          make wiki-home
+      - name: Update wiki
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automated update
+          repository: reports

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ latest: clean setup $(LATEST_TAG)
 4.0.0: clean setup 4.0.0
 
 
-setup: $(COMPOSEFILES)
-$(COMPOSEFILES): ./build/make-dockerfiles.R ./build/write-compose.R $(STACKFILES)
+setup: ./build/make-dockerfiles.R ./build/write-compose.R ./build/make-bakejson.R $(STACKFILES)
 	./build/make-dockerfiles.R
 	./build/write-compose.R
+	./build/make-bakejson.R
 
 
 ## Builds all stacks

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ inspect-image/%:
 	-docker run --rm $(@F) python3 -m pip list --disable-pip-version-check > $(REPORT_SOURCE_ROOT)/$(@F)/pip_packages.ssv
 inspect-image-all: $(foreach I, $(shell docker image ls -q -f "$(IMAGE_FILTER)"), inspect-image/$(I))
 	mkdir -p $(IMAGELIST_DIR)
-	docker image ls -f "label=org.opencontainers.image.source=$(IMAGE_SOURCE)" --format "{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.CreatedAt}}" > $(IMAGELIST_DIR)/$(IMAGELIST_NAME)
+	docker image ls -f "$(IMAGE_FILTER)" --format "{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.CreatedAt}}" > $(IMAGELIST_DIR)/$(IMAGELIST_NAME)
 
 REPORT_SOURCE_DIR := $(wildcard $(REPORT_SOURCE_ROOT)/*)
 report/%:

--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.0",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.0",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.0",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.0",
+      "tags": [
+        "docker.io/rocker/verse:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.0",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.0",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.0",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.0",
+      "tags": [
+        "docker.io/rocker/binder:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.0",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.0-cuda10.1",
+        "docker.io/rocker/cuda:4.0.0",
+        "docker.io/rocker/r-ver:4.0.0-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.0",
+      "tags": [
+        "docker.io/rocker/ml:4.0.0-cuda10.1",
+        "docker.io/rocker/ml:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.0",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.0-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.1",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.1",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.1",
+      "tags": [
+        "docker.io/rocker/verse:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.1",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.1",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.1",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.1",
+      "tags": [
+        "docker.io/rocker/binder:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.1",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.1-cuda10.1",
+        "docker.io/rocker/cuda:4.0.1",
+        "docker.io/rocker/r-ver:4.0.1-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.1",
+      "tags": [
+        "docker.io/rocker/ml:4.0.1-cuda10.1",
+        "docker.io/rocker/ml:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.1-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.2",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.2",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.2",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.2",
+      "tags": [
+        "docker.io/rocker/verse:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.2",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.2",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.2",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.2",
+      "tags": [
+        "docker.io/rocker/binder:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.2",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.2-cuda10.1",
+        "docker.io/rocker/cuda:4.0.2",
+        "docker.io/rocker/r-ver:4.0.2-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.2",
+      "tags": [
+        "docker.io/rocker/ml:4.0.2-cuda10.1",
+        "docker.io/rocker/ml:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.2",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.2-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.2"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.3",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.3",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.3",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.3",
+      "tags": [
+        "docker.io/rocker/verse:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.3",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.3",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.3",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.3",
+      "tags": [
+        "docker.io/rocker/binder:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.3",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.3-cuda10.1",
+        "docker.io/rocker/cuda:4.0.3",
+        "docker.io/rocker/r-ver:4.0.3-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.3",
+      "tags": [
+        "docker.io/rocker/ml:4.0.3-cuda10.1",
+        "docker.io/rocker/ml:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.3",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.3-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.3"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.4",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.4",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.4",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.4",
+      "tags": [
+        "docker.io/rocker/verse:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.4",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.4",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.4",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.4",
+      "tags": [
+        "docker.io/rocker/binder:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.4",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.4-cuda10.1",
+        "docker.io/rocker/cuda:4.0.4",
+        "docker.io/rocker/r-ver:4.0.4-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.4",
+      "tags": [
+        "docker.io/rocker/ml:4.0.4-cuda10.1",
+        "docker.io/rocker/ml:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.4",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.4-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.4"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -1,0 +1,132 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.5",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.5",
+        "docker.io/rocker/r-ver:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.5",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.5",
+        "docker.io/rocker/rstudio:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.5",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.5",
+        "docker.io/rocker/tidyverse:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.5",
+      "tags": [
+        "docker.io/rocker/verse:4.0.5",
+        "docker.io/rocker/verse:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.5",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.5",
+        "docker.io/rocker/geospatial:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.0.5",
+      "tags": [
+        "docker.io/rocker/shiny:4.0.5",
+        "docker.io/rocker/shiny:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.0.5",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.0.5",
+        "docker.io/rocker/shiny-verse:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.0.5",
+      "tags": [
+        "docker.io/rocker/binder:4.0.5",
+        "docker.io/rocker/binder:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.0.5",
+      "tags": [
+        "docker.io/rocker/cuda:4.0.5-cuda10.1",
+        "docker.io/rocker/cuda:4.0-cuda10.1",
+        "docker.io/rocker/cuda:4.0.5",
+        "docker.io/rocker/cuda:4.0",
+        "docker.io/rocker/r-ver:4.0.5-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.5",
+      "tags": [
+        "docker.io/rocker/ml:4.0.5-cuda10.1",
+        "docker.io/rocker/ml:4.0-cuda10.1",
+        "docker.io/rocker/ml:4.0.5",
+        "docker.io/rocker/ml:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.5",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.5-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0-cuda10.1",
+        "docker.io/rocker/ml-verse:4.0.5",
+        "docker.io/rocker/ml-verse:4.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.1.0",
+      "tags": [
+        "docker.io/rocker/r-ver:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.1.0",
+      "tags": [
+        "docker.io/rocker/rstudio:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.1.0",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.1.0",
+      "tags": [
+        "docker.io/rocker/verse:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.1.0",
+      "tags": [
+        "docker.io/rocker/geospatial:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.1.0",
+      "tags": [
+        "docker.io/rocker/shiny:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.1.0",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.1.0",
+      "tags": [
+        "docker.io/rocker/binder:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.1.0",
+      "tags": [
+        "docker.io/rocker/cuda:4.1.0-cuda10.1",
+        "docker.io/rocker/cuda:4.1.0",
+        "docker.io/rocker/r-ver:4.1.0-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.1.0",
+      "tags": [
+        "docker.io/rocker/ml:4.1.0-cuda10.1",
+        "docker.io/rocker/ml:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.1.0",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.1.0-cuda10.1",
+        "docker.io/rocker/ml-verse:4.1.0"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -1,0 +1,160 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.1.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.1.1",
+        "docker.io/rocker/r-ver:4.1",
+        "docker.io/rocker/r-ver:4",
+        "docker.io/rocker/r-ver:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.1.1",
+      "tags": [
+        "docker.io/rocker/rstudio:4.1.1",
+        "docker.io/rocker/rstudio:4.1",
+        "docker.io/rocker/rstudio:4",
+        "docker.io/rocker/rstudio:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.1.1",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.1.1",
+        "docker.io/rocker/tidyverse:4.1",
+        "docker.io/rocker/tidyverse:4",
+        "docker.io/rocker/tidyverse:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.1.1",
+      "tags": [
+        "docker.io/rocker/verse:4.1.1",
+        "docker.io/rocker/verse:4.1",
+        "docker.io/rocker/verse:4",
+        "docker.io/rocker/verse:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.1.1",
+      "tags": [
+        "docker.io/rocker/geospatial:4.1.1",
+        "docker.io/rocker/geospatial:4.1",
+        "docker.io/rocker/geospatial:4",
+        "docker.io/rocker/geospatial:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_4.1.1",
+      "tags": [
+        "docker.io/rocker/shiny:4.1.1",
+        "docker.io/rocker/shiny:4.1",
+        "docker.io/rocker/shiny:4",
+        "docker.io/rocker/shiny:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_4.1.1",
+      "tags": [
+        "docker.io/rocker/shiny-verse:4.1.1",
+        "docker.io/rocker/shiny-verse:4.1",
+        "docker.io/rocker/shiny-verse:4",
+        "docker.io/rocker/shiny-verse:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_4.1.1",
+      "tags": [
+        "docker.io/rocker/binder:4.1.1",
+        "docker.io/rocker/binder:4.1",
+        "docker.io/rocker/binder:4",
+        "docker.io/rocker/binder:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_4.1.1",
+      "tags": [
+        "docker.io/rocker/cuda:4.1.1-cuda10.1",
+        "docker.io/rocker/cuda:4.1-cuda10.1",
+        "docker.io/rocker/cuda:4-cuda10.1",
+        "docker.io/rocker/cuda:cuda10.1",
+        "docker.io/rocker/cuda:4.1.1",
+        "docker.io/rocker/cuda:4.1",
+        "docker.io/rocker/cuda:4",
+        "docker.io/rocker/cuda:latest",
+        "docker.io/rocker/r-ver:4.1.1-cuda10.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.1.1",
+      "tags": [
+        "docker.io/rocker/ml:4.1.1-cuda10.1",
+        "docker.io/rocker/ml:4.1-cuda10.1",
+        "docker.io/rocker/ml:4-cuda10.1",
+        "docker.io/rocker/ml:cuda10.1",
+        "docker.io/rocker/ml:4.1.1",
+        "docker.io/rocker/ml:4.1",
+        "docker.io/rocker/ml:4",
+        "docker.io/rocker/ml:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.1.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.1.1-cuda10.1",
+        "docker.io/rocker/ml-verse:4.1-cuda10.1",
+        "docker.io/rocker/ml-verse:4-cuda10.1",
+        "docker.io/rocker/ml-verse:cuda10.1",
+        "docker.io/rocker/ml-verse:4.1.1",
+        "docker.io/rocker/ml-verse:4.1",
+        "docker.io/rocker/ml-verse:4",
+        "docker.io/rocker/ml-verse:latest"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/core-4.0.0-ubuntu18.04.docker-bake.json
+++ b/bakefiles/core-4.0.0-ubuntu18.04.docker-bake.json
@@ -1,0 +1,44 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.0-ubuntu18.04",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_4.0.0-ubuntu18.04",
+      "tags": [
+        "docker.io/rocker/rstudio:4.0.0-ubuntu18.04"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_4.0.0-ubuntu18.04",
+      "tags": [
+        "docker.io/rocker/tidyverse:4.0.0-ubuntu18.04"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_4.0.0-ubuntu18.04",
+      "tags": [
+        "docker.io/rocker/verse:4.0.0-ubuntu18.04"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/core-latest-daily.docker-bake.json
+++ b/bakefiles/core-latest-daily.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_latest-daily",
+      "tags": [
+        "docker.io/rocker/rstudio:latest-daily"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_latest-daily",
+      "tags": [
+        "docker.io/rocker/tidyverse:latest-daily"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_latest-daily",
+      "tags": [
+        "docker.io/rocker/verse:latest-daily"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/devel.docker-bake.json
+++ b/bakefiles/devel.docker-bake.json
@@ -1,0 +1,118 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_devel",
+      "tags": [
+        "docker.io/rocker/r-ver:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "rstudio": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_rstudio_devel",
+      "tags": [
+        "docker.io/rocker/rstudio:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "tidyverse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_tidyverse_devel",
+      "tags": [
+        "docker.io/rocker/tidyverse:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_verse_devel",
+      "tags": [
+        "docker.io/rocker/verse:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_devel",
+      "tags": [
+        "docker.io/rocker/geospatial:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny_devel",
+      "tags": [
+        "docker.io/rocker/shiny:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "shiny-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_shiny-verse_devel",
+      "tags": [
+        "docker.io/rocker/shiny-verse:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "binder": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_binder_devel",
+      "tags": [
+        "docker.io/rocker/binder:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "cuda": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_cuda_devel",
+      "tags": [
+        "docker.io/rocker/r-ver:devel-cuda10.1",
+        "docker.io/rocker/cuda:devel-cuda10.1",
+        "docker.io/rocker/cuda:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_devel",
+      "tags": [
+        "docker.io/rocker/ml:devel-cuda10.1",
+        "docker.io/rocker/ml:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_devel",
+      "tags": [
+        "docker.io/rocker/ml-verse:devel-cuda10.1",
+        "docker.io/rocker/ml-verse:devel"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-4.0.0-ubuntu18.04.docker-bake.json
+++ b/bakefiles/geospatial-4.0.0-ubuntu18.04.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.0-ubuntu18.04",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.0-ubuntu18.04"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-4.0.4-daily.docker-bake.json
+++ b/bakefiles/geospatial-4.0.4-daily.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "1": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_NA_",
+      "tags": [
+        "docker.io/rocker/:"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-dev-osgeo.docker-bake.json
+++ b/bakefiles/geospatial-dev-osgeo.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_dev-osgeo",
+      "tags": [
+        "docker.io/rocker/geospatial:dev-osgeo"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-ubuntugis-4.0.0.docker-bake.json
+++ b/bakefiles/geospatial-ubuntugis-4.0.0.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.0-ubuntugis",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.0-ubuntugis"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-ubuntugis-4.0.1.docker-bake.json
+++ b/bakefiles/geospatial-ubuntugis-4.0.1.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.1-ubuntugis",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.1-ubuntugis"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-ubuntugis-4.0.2.docker-bake.json
+++ b/bakefiles/geospatial-ubuntugis-4.0.2.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.2-ubuntugis",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.2-ubuntugis"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-ubuntugis-4.0.3.docker-bake.json
+++ b/bakefiles/geospatial-ubuntugis-4.0.3.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_4.0.3-ubuntugis",
+      "tags": [
+        "docker.io/rocker/geospatial:4.0.3-ubuntugis"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/geospatial-ubuntugis.docker-bake.json
+++ b/bakefiles/geospatial-ubuntugis.docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "target": {
+    "geospatial": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_geospatial_ubuntugis",
+      "tags": [
+        "docker.io/rocker/geospatial:ubuntugis"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/ml-cuda11.1-4.0.3.docker-bake.json
+++ b/bakefiles/ml-cuda11.1-4.0.3.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.3-cuda11.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.3-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.3-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml:4.0.3-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.3-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.3-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/ml-cuda11.1-4.0.4.docker-bake.json
+++ b/bakefiles/ml-cuda11.1-4.0.4.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.4-cuda11.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.4-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.4-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml:4.0.4-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.4-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.4-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/ml-cuda11.1-4.0.5.docker-bake.json
+++ b/bakefiles/ml-cuda11.1-4.0.5.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.0.5-cuda11.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.0.5-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.0.5-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml:4.0.5-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.0.5-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.0.5-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/ml-cuda11.1-4.1.0.docker-bake.json
+++ b/bakefiles/ml-cuda11.1-4.1.0.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_4.1.0-cuda11.1",
+      "tags": [
+        "docker.io/rocker/r-ver:4.1.0-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_4.1.0-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml:4.1.0-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_4.1.0-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:4.1.0-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/bakefiles/ml-cuda11.1-devel.docker-bake.json
+++ b/bakefiles/ml-cuda11.1-devel.docker-bake.json
@@ -1,0 +1,34 @@
+{
+  "target": {
+    "r-ver": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_r-ver_devel-cuda11.1",
+      "tags": [
+        "docker.io/rocker/r-ver:devel-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml_devel-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml:devel-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    },
+    "ml-verse": {
+      "context": "./",
+      "dockerfile": "dockerfiles/Dockerfile_ml-verse_devel-cuda11.1",
+      "tags": [
+        "docker.io/rocker/ml-verse:devel-cuda11.1"
+      ],
+      "platforms": [
+        "linux/amd64"
+      ]
+    }
+  }
+}

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -342,17 +342,25 @@ df_args <- .r_versions_data(min_version = 4.0) %>%
   dplyr::mutate(
     ctan_url = .latest_ctan_url(freeze_date),
     r_latest = dplyr::if_else(dplyr::row_number() == dplyr::n(), TRUE, FALSE)
-  ) %>%
-  dplyr::select(!tidyselect::ends_with("_date"))
+  )
 
 # Write json file for GitHubActions build matrix.
 df_args %>%
   dplyr::select(r_version, r_latest) %>%
-  utils::tail(1) %>%
   {
-    list(include = .)
-  } %>%
-  jsonlite::write_json("build/matrix/latest.json", pretty = TRUE, auto_unbox = TRUE)
+    jsonlite::write_json(
+      list(include = .),
+      "build/matrix/all.json",
+      pretty = TRUE,
+      auto_unbox = TRUE
+    )
+    jsonlite::write_json(
+      list(include = utils::tail(., 1)),
+      "build/matrix/latest.json",
+      pretty = TRUE,
+      auto_unbox = TRUE
+    )
+  }
 
 message("\nstart writing stack files.")
 

--- a/build/matrix/all.json
+++ b/build/matrix/all.json
@@ -1,0 +1,36 @@
+{
+  "include": [
+    {
+      "r_version": "4.0.0",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.1",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.2",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.3",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.4",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.0.5",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.1.0",
+      "r_latest": false
+    },
+    {
+      "r_version": "4.1.1",
+      "r_latest": true
+    }
+  ]
+}


### PR DESCRIPTION
Add another workflow definition file `reports.yml` (and related files) that separate only the reporting part from `core.yml`, which builds container images.

Since we need to `docker pull` for all tags in this workflow, I added `docker-bake.json` files for tag extraction.
`docker-bake.json` will be used for build in the future, so we will be able to refer to the exact same tag in build and pull.
And, I have made minor modifications to `make-stacks.R` to generate a new matrix file ` build/matrix/all.json` that is required to run jobs in parallel for each R version. This can also be used in `core.yml`.

Currently, reports are generated on every build, so I believe that this workflow is rarely needed except for the first time when we need to create a built report prior to the automatic report creation.
Therefore, triggering is currently manual only.
Please run it only once after merging this PR.

Run results on my fork

![image](https://user-images.githubusercontent.com/50911393/129172887-3eac5db2-5f73-4534-b7fe-60b56af511fc.png)

![image](https://user-images.githubusercontent.com/50911393/129185842-09a91187-8034-4294-9cf8-9d114c01f4c0.png)
