### PR TITLE
fix push targets

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -57,8 +57,8 @@ jobs:
           docker image tag rocker/ml-verse:${{ matrix.r_version }} rocker/ml-verse:${{ matrix.r_version }}-cuda10.1
           docker image push rocker/cuda:${{ matrix.r_version }}-cuda10.1
           docker image push rocker/r-ver:${{ matrix.r_version }}-cuda10.1
-          docker image push rocker/ml:${{ matrix.r_version }}
-          docker image push rocker/ml-verse:${{ matrix.r_version }}
+          docker image push rocker/ml:${{ matrix.r_version }}-cuda10.1
+          docker image push rocker/ml-verse:${{ matrix.r_version }}-cuda10.1
       - name: Push latest tagged Docker image
         if: matrix.r_latest == true
         run: |


### PR DESCRIPTION
Due to a correction error in my #214, `rocker/ml:4.1.1-cuda10.1` and `rocker/ml-verse:4.1.1-cuda10.1` were not pushed at last build.