### PR TITLE
Set up dependabot to automatically update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
A PR will be created by dependabot to update the workflow when a new version of a dependent action is published. See the following page for more details.
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot

Please note that dependabot updates every patch version, so immediately after merging this PR, a large number of PRs may be sent to revise the existing version notation.
