### PR TITLE
Update wiki home to show all images

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,9 +1,15 @@
 name: Report published images
 
 on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "build/reports/*.Rmd"
   workflow_run:
     workflows:
       - "Build & Push Core images"
+      - "Build & Push extra images"
     branches:
       - "master"
     types:
@@ -17,14 +23,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - id: set-json
-        run: |
-          JSON=build/matrix/all.json
-          echo ::set-output name=json::${JSON}
-          echo ${JSON}
       - id: set-matrix
         run: |
-          CONTENT=$(jq -r 'with_entries(select(.key == "r_version")) | tostring' ${{ steps.set-json.outputs.json }})
+          CONTENT=$(jq -r 'with_entries(select(.key == "r_version")) | .r_version += ["extra"]' build/matrix/all.json)
           echo ::set-output name=matrix::${CONTENT}
           echo ${CONTENT}
 

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -89,15 +89,34 @@ For more general information about the Rocker Project, check out [the rocker-org
 
 *This page was generated from `r system("git rev-parse HEAD", intern = TRUE) |> .link_to_commit()`.*
 
-## Tagged images
+## Active tagged images
 
-The currently tagged images are as follows.  
+The currently updated images are as follows.  
 Click on the ID to see detailed information about each image.
+
+### Versioned images
 
 ```{r print_table}
 df_all |>
   dplyr::arrange(order_number) |>
   dplyr::filter(stack != "extra") |>
+  dplyr::transmute(
+    R = version,
+    ImageName = image_title,
+    RepoTags = tags,
+    ID = stringr::str_c("[[", id, "]]"),
+    CreatedTime
+  )
+```
+
+### Extra images
+
+The following images are experimental and may differ from other images in terms of the repositories used.
+
+```{r print_extra_table}
+df_all |>
+  dplyr::arrange(order_number) |>
+  dplyr::filter(stack == "extra") |>
   dplyr::transmute(
     R = version,
     ImageName = image_title,

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -67,7 +67,9 @@ df_all <- df_definitions |>
   dplyr::mutate(tags = stringr::str_remove(tags, "^docker.io/library|^docker.io/")) |>
   dplyr::inner_join(df_images, by = "tags") |>
   dplyr::group_by(id) |>
+  dplyr::slice_max(order_by = CreatedTime, with_ties = TRUE) |>
   dplyr::mutate(tags = stringr::str_c("`", stringr::str_c(tags, collapse = "`<br/>`"), "`")) |>
+  dplyr::filter(stringr::str_detect(tags, version) | stack == "extra") |>
   dplyr::slice_head(n = 1) |>
   dplyr::ungroup() |>
   tidyr::drop_na()
@@ -118,7 +120,6 @@ df_all |>
   dplyr::arrange(order_number) |>
   dplyr::filter(stack == "extra") |>
   dplyr::transmute(
-    R = version,
     ImageName = image_title,
     RepoTags = tags,
     ID = stringr::str_c("[[", id, "]]"),

--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -10,13 +10,67 @@ output:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, message = FALSE)
+knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot::is_git_root))
 
 library(fs)
 library(dplyr)
 library(readr)
+library(tibble)
+library(tidyr)
+library(purrr)
 library(forcats)
 library(stringr)
 library(lubridate)
+library(jsonlite)
+```
+
+```{r data_manipulation}
+.read_bakefile <- function(file) {
+  jsonlite::read_json(file)$target |>
+    tibble::enframe() |>
+    tidyr::hoist(
+      value,
+      version = c("labels", "org.opencontainers.image.version"),
+      image_title = c("labels", "org.opencontainers.image.title"),
+      tags = "tags"
+    ) |>
+    tidyr::unnest_longer(tags) |>
+    dplyr::select(name, version, image_title, tags)
+}
+
+
+df_definitions <- fs::dir_ls(
+  path = "bakefiles",
+  regexp = "([0-9]+\\.[0-9]+\\.[0-9]+|extra)\\.docker-bake.json$"
+) |>
+  rev() |>
+  purrr::map_dfr(.read_bakefile, .id = "file") |>
+  dplyr::mutate(
+    stack = stringr::str_remove_all(file, ".*/|\\.docker-bake\\.json"),
+    order_number = dplyr::row_number()
+  )
+
+df_images <- fs::dir_ls(path = "reports/imagelist", glob = "*.tsv") |>
+  readr::read_tsv(col_names = FALSE) |>
+  dplyr::filter(X3 != "<none>") |>
+  dplyr::transmute(
+    id = X1,
+    tags = stringr::str_c(X2, ":", X3),
+    CreatedTime = lubridate::ymd_hms(X4)
+  ) |>
+  dplyr::group_by(tags) |>
+  dplyr::slice_max(order_by = CreatedTime, with_ties = TRUE) |>
+  dplyr::ungroup()
+
+
+df_all <- df_definitions |>
+  dplyr::mutate(tags = stringr::str_remove(tags, "^docker.io/library|^docker.io/")) |>
+  dplyr::inner_join(df_images, by = "tags") |>
+  dplyr::group_by(id) |>
+  dplyr::mutate(tags = stringr::str_c("`", stringr::str_c(tags, collapse = "`<br/>`"), "`")) |>
+  dplyr::slice_head(n = 1) |>
+  dplyr::ungroup() |>
+  tidyr::drop_na()
 ```
 
 ```{r}
@@ -40,46 +94,15 @@ For more general information about the Rocker Project, check out [the rocker-org
 The currently tagged images are as follows.  
 Click on the ID to see detailed information about each image.
 
-```{r}
-repos <- paste0(
-  "rocker/",
-  c("r-ver", "rstudio", "tidyverse", "verse", "geospatial", "shiny", "shiny-verse", "binder", "cuda", "ml", "ml-verse")
-) |>
-  forcats::as_factor()
-
-df_all <- fs::dir_ls(path = "../../reports/imagelist", glob = "*.tsv") |>
-  readr::read_tsv(col_names = FALSE) |>
-  dplyr::transmute(
-    id = X1,
-    repo = X2,
-    tag = X3,
-    CreatedTime = lubridate::ymd_hms(X4)
-  ) |>
-  dplyr::filter(tag != "<none>") |>
-  dplyr::distinct(id, repo, tag, .keep_all = TRUE)
-
-df_tags <- df_all |>
-  dplyr::mutate(repo_tags = paste0(repo, ":", tag)) |>
-  dplyr::arrange(desc(repo_tags)) |>
-  dplyr::group_by(id) |>
-  dplyr::summarise(repo_tags = paste0(repo_tags, collapse = "`<br/>`"), .groups = "drop") |>
-  dplyr::transmute(
-    id,
-    RepoTags = paste0("`", repo_tags, "`")
-  )
-
+```{r print_table}
 df_all |>
-  dplyr::filter(repo %in% repos & stringr::str_detect(tag, "^\\d\\.\\d\\.\\d$")) |>
-  dplyr::group_by(repo, tag) |>
-  dplyr::slice_max(order_by = CreatedTime) |>
-  dplyr::ungroup() |>
-  dplyr::left_join(df_tags, by = "id") |>
-  dplyr::arrange(desc(tag), match(repo, repos)) |>
+  dplyr::arrange(order_number) |>
+  dplyr::filter(stack != "extra") |>
   dplyr::transmute(
-    R = tag,
-    ImageName = paste0("[`", repo, "`](https://hub.docker.com/r/", repo, ")"),
-    RepoTags,
-    ID = paste0("[`", id, "`](https://github.com/rocker-org/rocker-versioned2/wiki/", id, ")"),
+    R = version,
+    ImageName = image_title,
+    RepoTags = tags,
+    ID = stringr::str_c("[[", id, "]]"),
     CreatedTime
   )
 ```


### PR DESCRIPTION
Update the wiki template to match the build changes made in #227

Change the list of images displayed in the wiki home to be generated from docker-bake.json, so that all images are displayed in the table.
Also, make minor changes to the appearance. (to make it easier to see the history differences, plane text)


Change appearance(Remove hyperlinks at `ImageName`, `ID`s are no longer codes)

![image](https://user-images.githubusercontent.com/50911393/132689710-b91a2057-185f-47f9-83e9-c1ebaffe3a1e.png)

Show cuda11 images, 4.0.0-ubuntu18.04 images, extra images.

![image](https://user-images.githubusercontent.com/50911393/132689779-e09c6001-9204-4164-9ce5-523159ac8c62.png)

![image](https://user-images.githubusercontent.com/50911393/132724732-9a0d6232-26c2-4017-9ea6-300b7d0c3f64.png)

