### PR TITLE
Change the naming convention for reports uploaded to the wiki

### DIFF
--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -72,7 +72,32 @@ df_all <- df_definitions |>
   dplyr::filter(stringr::str_detect(tags, version) | stack == "extra") |>
   dplyr::slice_head(n = 1) |>
   dplyr::ungroup() |>
-  tidyr::drop_na()
+  tidyr::drop_na() |>
+  dplyr::mutate(report_name = stringr::str_c(name, "_", id))
+```
+
+```{r rename_reports}
+.remove_old_report <- function(id, path = "reports", filename_prefix = ".*_") {
+  old_reports <- fs::dir_ls(path) |>
+    stringr::str_subset(stringr::str_c(filename_prefix, id))
+
+  if (length(old_reports) >= 1) fs::file_delete(old_reports)
+
+  return(invisible())
+}
+
+.rename_report <- function(id, new_file, path = "reports") {
+  report_path <- fs::path(path, id, ext = "md")
+  report_new_path <- fs::path(path, new_file, ext = "md")
+
+  fs::file_move(report_path, report_new_path)
+
+  return(invisible())
+}
+
+
+purrr::walk(df_all$id, .remove_old_report)
+purrr::walk2(df_all$id, df_all$report_name, .rename_report)
 ```
 
 ```{r}
@@ -106,7 +131,7 @@ df_all |>
     R = version,
     ImageName = image_title,
     RepoTags = tags,
-    ID = stringr::str_c("[[", id, "]]"),
+    ID = stringr::str_c("[[", id, "|", report_name, "]]"),
     CreatedTime
   )
 ```
@@ -122,7 +147,7 @@ df_all |>
   dplyr::transmute(
     ImageName = image_title,
     RepoTags = tags,
-    ID = stringr::str_c("[[", id, "]]"),
+    ID = stringr::str_c("[[", id, "|", report_name, "]]"),
     CreatedTime
   )
 ```


### PR DESCRIPTION
The filenames of the reports currently saved as wiki pages are the image IDs.
These filenames are hard to guess when displayed in search results on GitHub.

![image](https://user-images.githubusercontent.com/50911393/132874446-8f39f1c4-5132-43cf-8369-23b00cf6638b.png)

Therefore, by this PR, the file names will be changed to include the image names. The new report will appear in the search results as follows:

![image](https://user-images.githubusercontent.com/50911393/132874454-9d50f9f2-2914-4ef3-acb3-ca1da46d5e28.png)

Renaming the files of the reports is done in the process of generating the wiki home, but the appearance of the wiki home is not changed in this PR.