### PR TITLE
Add change logs to each releases automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,20 @@ jobs:
       tag: ${{ steps.tag-version.outputs.new_tag }}
     steps:
       - uses: actions/checkout@v2
+
       - id: set-version
         run: |
-          VERSION=$(jq '.r_version[-1]' -r build/matrix/latest.json)
-          echo ::set-output name=version::${VERSION}
+          NEW_VERSION=$(jq '.r_version[-1]' -r build/matrix/latest.json)
+          echo ::set-output name=newversion::${NEW_VERSION}
           echo ${VERSION}
+
       - name: Bump version and push tag
         id: tag-version
         uses: mathieudutour/github-tag-action@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
-          custom_tag: ${{ steps.set-version.outputs.version }}
+          custom_tag: ${{ steps.set-version.outputs.newversion }}
           tag_prefix: "R"
 
   create_release:
@@ -33,8 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ncipollo/release-action@v1
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configuration: "build/changelog_configuration.json"
+          toTag: ${{ needs.create_tag.outputs.tag }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.create_tag.outputs.tag }}
+          body: ${{steps.build_changelog.outputs.changelog}}
           allowUpdates: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/build/changelog_configuration.json
+++ b/build/changelog_configuration.json
@@ -1,0 +1,14 @@
+{
+  "ignore_labels": [
+    "ignore"
+  ],
+  "sort": "ASC",
+  "template": "${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes",
+  "max_pull_requests": 1000,
+  "max_back_track_time_days": 1000,
+  "tag_resolver": {
+    "method": "sort"
+  }
+}


### PR DESCRIPTION
Update the release action to generate a change log (PRs) and list it in the release automatically.
It will be easier to see the differences between releases.
(It was a feature I wanted to implement at stage #223, but I couldn't make it in time.)

![image](https://user-images.githubusercontent.com/50911393/133090342-95657857-b7e5-4896-8ce2-e299c6dbb0df.png)

See the repository for this action for customizing release documentation.
https://github.com/mikepenz/release-changelog-builder-action
