### PR TITLE
Report template update for multi-architecture images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ inspect-image-all: $(foreach I, $(shell docker image ls -q -f "$(IMAGE_FILTER)")
 
 report/%:
 	mkdir -p $(REPORT_DIR)
-	-./build/knit-report.R -d ../../$* $(@F) $(REPORT_DIR)
+	-./build/knit-report.R -d $* $(@F) $(REPORT_DIR)
 report-all: $(foreach I, $(wildcard $(REPORT_SOURCE_ROOT)/*), report/$(I))
 
 

--- a/build/knit-report.R
+++ b/build/knit-report.R
@@ -7,19 +7,20 @@ arguments <- "
 Generate a report of container image's infomation.
 
 Usage:
-  knit-report.R [-i <inspect_file>] [-a <apt_file>] [-r <r_file>] [-p <pip_file>] <image_name> <output_dir>
+  knit-report.R [-i <inspect_file>] [-m <manifest_file>] [-a <apt_file>] [-r <r_file>] [-p <pip_file>] <image_name> <output_dir>
   knit-report.R [-d <directory_name>] <image_name> <output_dir>
 
 Options:
   -i --inspect    `docker instpect image` output file.
+  -m --manifest   `docker buildx imagetools inspect` output file.
   -a --apt        `dpkg-query --show --showformat='${Package}\\t${Version}\\n'` output file.
   -r --R          `Rscript -e 'as.data.frame(installed.packages()[, 3])` output file.'
   -p --pip        `python3 -m pip list --disable-pip-version-check` output file.
   -d --directory  Directory, which contains source files, `docker_inspect.json`, `apt_packages.tsv`, `r_packages.ssv`, `pip_packages.ssv`.
 
 Examples:
-  knit-report.R -i tmp/imageid/docker_inspect.json -a tmp/imageid/apt_packages.tsv -r tmp/imageid/r_packages.ssv -p tmp/imageid/pip_packages.ssv imageid reports
-  knit-report.R -d tmp/imageid imageid reports
+  ./build/knit-report.R -i docker_inspect.json -m imagetools_inspect.txt -a apt_packages.tsv -r r_packages.ssv -p pip_packages.ssv imageid reports
+  ./build/knit-report.R -d tmp/imageid imageid reports
 " |>
   docopt::docopt()
 
@@ -29,6 +30,7 @@ image_name <- arguments$image_name
 output_dir <- arguments$output_dir
 
 inspect_file <- arguments$inspect_file
+imagetotls_inspect_file <- arguments$manifest_file
 apt_file <- arguments$apt_file
 r_file <- arguments$r_file
 pip_file <- arguments$pip_file
@@ -36,6 +38,7 @@ pip_file <- arguments$pip_file
 if (arguments$directory == TRUE) {
   directory_name <- arguments$directory_name
   inspect_file <- paste0(directory_name, "/docker_inspect.json")
+  imagetotls_inspect_file <- paste0(directory_name, "/imagetools_inspect.txt")
   apt_file <- paste0(directory_name, "/apt_packages.tsv")
   r_file <- paste0(directory_name, "/r_packages.ssv")
   pip_file <- paste0(directory_name, "/pip_packages.ssv")
@@ -48,6 +51,7 @@ rmarkdown::render(
   params = list(
     image_name = image_name,
     inspect_file = inspect_file,
+    imagetotls_inspect_file = imagetotls_inspect_file,
     apt_file = apt_file,
     r_file = r_file,
     pip_file = pip_file

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -106,7 +106,7 @@ df_digest <- tryCatch(
 )
 
 if (!is.null(df_digest)) {
-  cat("### Other platforms \n\n This image was created by a multi-architecture build. The digests for each platform are as follows.")
+  cat("### Platforms \n\n This image was created by a multi-architecture build. The digests for each platform are as follows.")
 
   df_digest |>
     dplyr::mutate(RepoDigests = paste0("`", RepoDigests, "`")) |>

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -19,6 +19,15 @@ knitr::opts_chunk$set(echo = FALSE, message = FALSE)
 knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot::is_git_root))
 ```
 
+```{r load_packages, include=FALSE}
+library(jsonlite)
+library(readr)
+library(dplyr)
+library(tibble)
+library(tidyr)
+library(tidyselect)
+```
+
 ```{r}
 .link_to_commit <- function(commit_hash) {
   base_url <- "https://github.com/rocker-org/rocker-versioned2/tree/"
@@ -47,15 +56,16 @@ knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot:
 
 jsonlite::read_json(params$inspect_file) |>
   tibble::enframe() |>
-  dplyr::transmute(
-    ImageID = purrr::map_chr(value, "Id"),
-    RepoTags = purrr::map(value, "RepoTags"),
-    RepoDigests = purrr::map(value, "RepoDigests"),
-    ImageSource = purrr::map_chr(value, c("Config", "Labels", "org.opencontainers.image.source"), .default = NA_character_),
-    ImageRevision = purrr::map_chr(value, c("Config", "Labels", "org.opencontainers.image.revision"), .default = NA_character_),
-    CreatedTime = purrr::map_chr(value, "Created", .default = NA_character_),
-    Size = purrr::map_dbl(value, "Size", .default = NA_real_),
-    Env = purrr::map(value, c("Config", "Env"))
+  tidyr::hoist(
+    .col = value,
+    ImageID = "Id",
+    "RepoTags",
+    "RepoDigests",
+    ImageSource = list("Config", "Labels", "org.opencontainers.image.source"),
+    ImageRevision = list("Config", "Labels", "org.opencontainers.image.revision"),
+    CreatedTime = "Created",
+    "Size",
+    Env = list("Config", "Env")
   ) |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),
@@ -64,6 +74,7 @@ jsonlite::read_json(params$inspect_file) |>
     Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = paste(unlist(Env), collapse = ", ")
   ) |>
+  dplyr::select(tidyselect:::where(is.character)) |>
   tidyr::pivot_longer(cols = tidyselect::everything())
 ```
 

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -16,6 +16,7 @@ params:
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE, message = FALSE)
+knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot::is_git_root))
 ```
 
 ```{r}

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -9,13 +9,14 @@ output:
 params:
   image_name: ""
   inspect_file: ""
+  imagetotls_inspect_file: ""
   apt_file: ""
   r_file: ""
   pip_file: ""
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE, message = FALSE)
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot::is_git_root))
 ```
 
@@ -26,6 +27,7 @@ library(dplyr)
 library(tibble)
 library(tidyr)
 library(tidyselect)
+library(purrr)
 ```
 
 ```{r prepare_texts}
@@ -60,7 +62,7 @@ image_arch <- jsonlite::read_json(params$inspect_file) |>
   return(chr)
 }
 
-jsonlite::read_json(params$inspect_file) |>
+df_inspect <- jsonlite::read_json(params$inspect_file) |>
   tibble::enframe() |>
   tidyr::hoist(
     .col = value,
@@ -72,7 +74,9 @@ jsonlite::read_json(params$inspect_file) |>
     CreatedTime = "Created",
     "Size",
     Env = list("Config", "Env")
-  ) |>
+  )
+
+df_inspect |>
   dplyr::mutate(
     ImageID = paste0("`", ImageID, "`"),
     RepoTags = .unlist_and_enclose(RepoTags),
@@ -82,6 +86,32 @@ jsonlite::read_json(params$inspect_file) |>
   ) |>
   dplyr::select(tidyselect:::where(is.character)) |>
   tidyr::pivot_longer(cols = tidyselect::everything())
+```
+
+You can install this image with a command with a RepoDigests, like the following:
+
+```shell
+docker pull `r df_inspect$RepoDigests |> purrr::chuck(1, 1)`
+```
+
+```{r imagetools_inspect, results='asis'}
+df_digest <- tryCatch(
+  readr::read_table(params$imagetotls_inspect_file, col_names = c("name", "value")) |>
+    dplyr::filter(name %in% c("Name:", "Platform:")) |>
+    dplyr::filter(!(name == "Name:" & dplyr::lead(name) != "Platform:")) |>
+    dplyr::mutate(id = (row_number() + 1) %/% 2) |>
+    tidyr::pivot_wider(id_cols = id) |>
+    dplyr::transmute(platform = `Platform:`, RepoDigests = `Name:`),
+  error = function(e) NULL
+)
+
+if (!is.null(df_digest)) {
+  cat("### Other platforms \n\n This image was created by a multi-architecture build. The digests for each platform are as follows.")
+
+  df_digest |>
+    dplyr::mutate(RepoDigests = paste0("`", RepoDigests, "`")) |>
+    knitr::kable()
+}
 ```
 
 ## Installed packages

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -28,7 +28,7 @@ library(tidyr)
 library(tidyselect)
 ```
 
-```{r}
+```{r prepare_texts}
 .link_to_commit <- function(commit_hash) {
   base_url <- "https://github.com/rocker-org/rocker-versioned2/tree/"
   commit_short_hash <- commit_hash |>
@@ -49,7 +49,7 @@ image_arch <- jsonlite::read_json(params$inspect_file) |>
 
 ## Image info
 
-```{r}
+```{r docker_inspect}
 .unlist_and_enclose <- function(x) {
   chr <- dplyr::if_else(
     !is.null(unlist(x)),
@@ -88,7 +88,7 @@ jsonlite::read_json(params$inspect_file) |>
 
 ### apt packages
 
-```{r}
+```{r apt_packages}
 readr::read_tsv(params$apt_file, col_names = FALSE) |>
   dplyr::transmute(
     package = X1,
@@ -98,7 +98,7 @@ readr::read_tsv(params$apt_file, col_names = FALSE) |>
 
 ### R packages
 
-```{r}
+```{r r_packages}
 readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
   dplyr::transmute(
     package = X1,
@@ -108,7 +108,7 @@ readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
 
 ### Python3 pip packages
 
-```{r}
+```{r pip_packages}
 try(
   readr::read_table(params$pip_file, skip = 2, col_names = FALSE) |>
     dplyr::transmute(

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -37,9 +37,15 @@ library(tidyselect)
 
   return(linked_text)
 }
+
+commit_link <- system("git rev-parse HEAD", intern = TRUE) |>
+  .link_to_commit()
+
+image_arch <- jsonlite::read_json(params$inspect_file) |>
+  purrr::map_chr("Architecture")
 ```
 
-*This report was generated from `r system("git rev-parse HEAD", intern = TRUE) |> .link_to_commit()`.*
+*This report was generated from `r commit_link`, and based on the `r image_arch` architecture image.*
 
 ## Image info
 


### PR DESCRIPTION
The current reports do not contain information about the architecture of the target image, so I added this.
The multi-architecture images report also adds a list of available architectures.

Currently, there is no multi-architecture built image from this repository yet, so here is the result of testing with `r-base`.

![image](https://user-images.githubusercontent.com/50911393/134699256-dfc9581f-b9b1-4179-b569-55d1375a3256.png)

The report on images for amd64 only builds does not show a list of platforms.

![image](https://user-images.githubusercontent.com/50911393/134689441-ee9dcf25-9784-49f6-a190-1431e734e782.png)

**ToDo**

- [x] Test GitHub Actions workflow on my fork.
