### PR TITLE
bump s6 overlay to v2.1.0.2 in R <= 4.0.2 images

### DIFF
--- a/dockerfiles/ml_4.0.0.Dockerfile
+++ b/dockerfiles/ml_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default

--- a/dockerfiles/ml_4.0.1.Dockerfile
+++ b/dockerfiles/ml_4.0.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default

--- a/dockerfiles/ml_4.0.2.Dockerfile
+++ b/dockerfiles/ml_4.0.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.1093
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default

--- a/dockerfiles/rstudio-ubuntu18.04_4.0.0.Dockerfile
+++ b/dockerfiles/rstudio-ubuntu18.04_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v1.21.7.0
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/rstudio_4.0.0.Dockerfile
+++ b/dockerfiles/rstudio_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/rstudio_4.0.1.Dockerfile
+++ b/dockerfiles/rstudio_4.0.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/rstudio_4.0.2.Dockerfile
+++ b/dockerfiles/rstudio_4.0.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.1093
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH

--- a/dockerfiles/shiny_4.0.0.Dockerfile
+++ b/dockerfiles/shiny_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default
 

--- a/dockerfiles/shiny_4.0.1.Dockerfile
+++ b/dockerfiles/shiny_4.0.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default
 

--- a/dockerfiles/shiny_4.0.2.Dockerfile
+++ b/dockerfiles/shiny_4.0.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV S6_VERSION=v2.0.0.1
+ENV S6_VERSION=v2.1.0.2
 ENV SHINY_SERVER_VERSION=latest
 ENV PANDOC_VERSION=default
 

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -52,7 +52,7 @@
       },
       "FROM": "rocker/r-ver:4.0.0",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
@@ -115,7 +115,7 @@
       },
       "FROM": "rocker/r-ver:4.0.0",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "SHINY_SERVER_VERSION": "latest",
         "PANDOC_VERSION": "default"
       },
@@ -204,7 +204,7 @@
       },
       "FROM": "rocker/cuda:4.0.0",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
@@ -275,7 +275,7 @@
       },
       "FROM": "rocker/r-ver:4.0.0-ubuntu18.04",
       "ENV": {
-        "S6_VERSION": "v1.21.7.0",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -38,7 +38,7 @@
       },
       "FROM": "rocker/r-ver:4.0.1",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
@@ -101,7 +101,7 @@
       },
       "FROM": "rocker/r-ver:4.0.1",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "SHINY_SERVER_VERSION": "latest",
         "PANDOC_VERSION": "default"
       },
@@ -190,7 +190,7 @@
       },
       "FROM": "rocker/cuda:4.0.1",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -38,7 +38,7 @@
       },
       "FROM": "rocker/r-ver:4.0.2",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.1093",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
@@ -101,7 +101,7 @@
       },
       "FROM": "rocker/r-ver:4.0.2",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "SHINY_SERVER_VERSION": "latest",
         "PANDOC_VERSION": "default"
       },
@@ -190,7 +190,7 @@
       },
       "FROM": "rocker/cuda:4.0.2",
       "ENV": {
-        "S6_VERSION": "v2.0.0.1",
+        "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.1093",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",


### PR DESCRIPTION
Fix #81
Supports starting services by non-root users.

Given that the images with R >= 4.0.3 have been using s6 overlay v2.1.0.2 for some time, I think this update is unlikely to cause any problems.

There seems to be a permission issue when running the container on singularity, but the workaround for this comment https://github.com/rocker-org/rocker-versioned2/issues/105#issuecomment-799848638 (or the rocker website https://github.com/rocker-org/website/pull/22 ?) seems to solve it.