### PR TITLE
Minor fix and some refactoring to `make-stacks.R`

### DIFF
--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -1,8 +1,9 @@
-name: Update Dockerfiles and docker-compose files
+name: Update container definition files
 
 on:
   schedule:
     - cron: "0 10 * * *"
+  workflow_dispatch:
 
 jobs:
   createPullRequest:


### PR DESCRIPTION
Sorry, let me change the following line that was changed in #248, because it may set latest RStudio version to Dockerfile before the installer is published.
(This value only checks the GitHub tag and does not check if the installer has been published.)

https://github.com/rocker-org/rocker-versioned2/blob/859d997998ec2bfe698d276751ff092968b54f95/build/make-stacks.R#L451

In addition, the following minor changes were made.

- More appropriate variable name
- `paste0` -> `stringr::str_c` (improve `NA` handling)
- Usage of the `dplyr::slice_*` functions more appropriately
- Rename the workflow, as there are far more files modified by the workflow than before.

I hope the update to RStudio 2021.09, which is expected to be released soon, will be successful.