### PR TITLE
Update for new RStudio versioning, download URL, and bump RStudio Server to 2021.09.0+351 in R 4.1.1 images

### DIFF
--- a/dockerfiles/ml-cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.1.1.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/ml-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-cuda11_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/ml_4.1.1.Dockerfile
+++ b/dockerfiles/ml_4.1.1.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
 ENV TENSORFLOW_VERSION=gpu

--- a/dockerfiles/ml_devel.Dockerfile
+++ b/dockerfiles/ml_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
 ENV TENSORFLOW_VERSION=gpu

--- a/dockerfiles/rstudio_4.1.1.Dockerfile
+++ b/dockerfiles/rstudio_4.1.1.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/rstudio_devel.Dockerfile
+++ b/dockerfiles/rstudio_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=1.4.1717
+ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -42,21 +42,26 @@ if [ -z "$1" ];
   else RSTUDIO_VERSION_ARG=$1;
 fi
 
+RSTUDIO_BASE_URL=https://download2.rstudio.org/server
+
 if [ -z "$RSTUDIO_VERSION_ARG" ] || [ "$RSTUDIO_VERSION_ARG" = "latest" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+%2B[0-9]+" -m 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "preview" ]; then
-    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-preview%2B[0-9]+" -m 1)
+    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-preview%2B[0-9]+" -m 1 ||
+      wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+%2B[0-9]+" -m 1)
+    RSTUDIO_BASE_URL=https://s3.amazonaws.com/rstudio-ide-build/server
 elif [ "$RSTUDIO_VERSION_ARG" = "daily" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-daily%2B[0-9]+" -m 1)
+    RSTUDIO_BASE_URL=https://s3.amazonaws.com/rstudio-ide-build/server
 else
     DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG/"+"/"%2B"}
 fi
 
 ## UBUNTU_VERSION is not generally valid: only works for xenial and bionic, not other releases,
 ## and does not understand numeric versions. (2020-04-15)
-#RSTUDIO_URL="https://download2.rstudio.org/server/${UBUNTU_VERSION}/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
+#RSTUDIO_URL="${RSTUDIO_BASE_URL}/${UBUNTU_VERSION}/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
 ## hardwire bionic for now...
-RSTUDIO_URL="https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
+RSTUDIO_URL="${RSTUDIO_BASE_URL}/bionic/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
 
 if [ "$UBUNTU_VERSION" = "xenial" ]; then
   wget "${RSTUDIO_URL}" || \

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -43,20 +43,20 @@ if [ -z "$1" ];
 fi
 
 if [ -z "$RSTUDIO_VERSION_ARG" ] || [ "$RSTUDIO_VERSION_ARG" = "latest" ]; then
-    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+" -m 1)
+    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+%2B[0-9]+" -m 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "preview" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-preview%2B[0-9]+" -m 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "daily" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudioserver/oss/ubuntu/x86_64/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-daily%2B[0-9]+" -m 1)
 else
-    DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG}
+    DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG/"+"/"%2B"}
 fi
 
 ## UBUNTU_VERSION is not generally valid: only works for xenial and bionic, not other releases,
 ## and does not understand numeric versions. (2020-04-15)
-#RSTUDIO_URL="https://s3.amazonaws.com/rstudio-ide-build/server/${UBUNTU_VERSION}/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
+#RSTUDIO_URL="https://download2.rstudio.org/server/${UBUNTU_VERSION}/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
 ## hardwire bionic for now...
-RSTUDIO_URL="https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
+RSTUDIO_URL="https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${DOWNLOAD_VERSION}-amd64.deb"
 
 if [ "$UBUNTU_VERSION" = "xenial" ]; then
   wget "${RSTUDIO_URL}" || \

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -60,7 +60,7 @@
       "FROM": "rocker/r-ver:4.1.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
@@ -245,7 +245,7 @@
       "FROM": "rocker/cuda:4.1.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
         "TENSORFLOW_VERSION": "gpu",
@@ -340,7 +340,7 @@
       "FROM": "rocker/cuda:4.1.1-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -47,7 +47,7 @@
       "FROM": "rocker/r-ver:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
@@ -178,7 +178,7 @@
       "FROM": "rocker/cuda:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
         "TENSORFLOW_VERSION": "gpu",
@@ -258,7 +258,7 @@
       "FROM": "rocker/cuda:devel-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "1.4.1717",
+        "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },


### PR DESCRIPTION
A new version of RStudio `2021.09.0+351` was released today, but due to changes in the tag naming convention and download URL, it could not be installed with the current installation script, and the automatic update did not detect the new version.

The following changes are required

- Replace `+` in version name with `%2B` for download URL.
- Update the base URL.
- The rstudio/rstudio GitHub repository tags naming changed from "vX.Y.Z" to "YYYY.MM.X+Z", so GitHub APIv3 couldn't get the latest tag because of sorting, so we need to get the tags with git (in R, the `gert` package).

**ToDo**

- [x] Update the definition files.
- [x] Install test.
  - [x] RStudio 1.4.1717
  - [x] RStudio 2021.09.0+351
  - [x] daily
  - [x] preview