### PR TITLE
Update some scripts to reduce build time (parallel installation R packages and skipping apt update)

### DIFF
--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -5,7 +5,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 apt-get update -qq \
   && apt-get install -y --no-install-recommends \

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -7,7 +7,10 @@ set -e
 PANDOC_VERSION=${1:-${PANDOC_VERSION:-default}}
 ARCH=$(dpkg --print-architecture)
 
-apt-get update && apt-get -y install wget
+if [ ! -x "$(command -v wget)" ]; then
+  apt-get update
+  apt-get -y install wget
+fi
 
 if [ -x "$(command -v pandoc)" ]; then
   INSTALLED_PANDOC=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -2,7 +2,7 @@
 set -e
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 WORKON_HOME=${WORKON_HOME:-/opt/venv}
 PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-${WORKON_HOME}/reticulate}

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -15,7 +15,10 @@ fi
 DOWNLOAD_FILE=s6-overlay-${ARCH}.tar.gz
 
 
-apt-get update && apt-get -y install wget
+if [ ! -x "$(command -v wget)" ]; then
+  apt-get update
+  apt-get -y install wget
+fi
 
 ## Set up S6 init system
 if [ -f "/rocker_scripts/.s6_version" ] && [ "$S6_VERSION" = "$(cat /rocker_scripts/.s6_version)" ]; then

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -4,7 +4,7 @@ set -e
 SHINY_SERVER_VERSION=${1:-${SHINY_SERVER_VERSION:-latest}}
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 # Run dependency scripts
 . /rocker_scripts/install_s6init.sh

--- a/scripts/install_tensorflow.sh
+++ b/scripts/install_tensorflow.sh
@@ -2,7 +2,7 @@
 set -e
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 TENSORFLOW_VERSION=${1:-${TENSORFLOW_VERSION:-default}}
 KERAS_VERSION=${2:-${KERAS_VERSION:-default}}

--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 set -e
 apt-get update -qq && apt-get -y --no-install-recommends install \

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -2,7 +2,7 @@
 set -e
 
 ## build ARGs
-NCPUS=${NCPUS:-1}
+NCPUS=${NCPUS:--1}
 
 # always set this for scripts but don't declare as ENV..
 export DEBIAN_FRONTEND=noninteractive

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -2,7 +2,11 @@
 
 ## https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2/
 
-apt-get update && apt-get -y install wget
+if [ ! -x "$(command -v wget)" ]; then
+  apt-get update
+  apt-get -y install wget
+fi
+
 cd /opt
 wget https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz
 tar -xvf wgrib2.tgz


### PR DESCRIPTION
I intended to set `--ncpus -1` to `install2.r` commands by default on #241 but noticed that it was set to `1`.
Setting `-1` may speed up the installation and reduce the build time.

The Ubuntu runner used in GitHub Actions has 2 cores, so it seems that the time-consuming source installation of R packages can be reduced by nearly half.

And, some scripts are running `apt-get update` just to install wget, so I changed it not to do `apt-get update` if wget is already installed.