### PR TITLE
Export build cache of `rocker/r-ver` to reduce build time

### DIFF
--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -49,6 +49,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.0"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -67,6 +70,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -87,6 +93,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -105,6 +114,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -125,6 +137,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -143,6 +158,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -163,6 +181,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -181,6 +202,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -203,6 +227,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -222,6 +249,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -243,6 +273,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "r-ver-ubuntu18.04": {
@@ -262,6 +295,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio-ubuntu18.04": {
@@ -280,6 +316,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -300,6 +339,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse-ubuntu18.04": {
@@ -319,6 +361,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "geospatial-ubuntu18.04": {
@@ -337,6 +382,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -26,6 +26,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -44,6 +47,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -64,6 +70,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -82,6 +91,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -102,6 +114,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -120,6 +135,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -140,6 +158,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -158,6 +179,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -180,6 +204,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -200,6 +227,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse": {
@@ -219,6 +249,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -26,6 +26,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.2"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -44,6 +47,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -64,6 +70,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -82,6 +91,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -102,6 +114,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -120,6 +135,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -140,6 +158,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -158,6 +179,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -180,6 +204,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -200,6 +227,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse": {
@@ -219,6 +249,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -26,6 +26,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.3"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -44,6 +47,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -64,6 +70,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -82,6 +91,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -102,6 +114,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -120,6 +135,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -140,6 +158,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -158,6 +179,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -180,6 +204,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -199,6 +226,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -220,6 +250,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -240,6 +273,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-cuda11": {
@@ -259,6 +295,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -277,6 +316,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -26,6 +26,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.4"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -44,6 +47,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -64,6 +70,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -82,6 +91,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -102,6 +114,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -120,6 +135,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -140,6 +158,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -158,6 +179,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -180,6 +204,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -199,6 +226,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -220,6 +250,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -240,6 +273,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-cuda11": {
@@ -259,6 +295,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -277,6 +316,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -27,6 +27,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.5"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -46,6 +49,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -67,6 +73,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -86,6 +95,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -107,6 +119,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -126,6 +141,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -147,6 +165,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -166,6 +187,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -190,6 +214,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -211,6 +238,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -234,6 +264,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -255,6 +288,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-cuda11": {
@@ -275,6 +311,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -294,6 +333,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -48,6 +48,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.1.0"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -66,6 +69,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -86,6 +92,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -104,6 +113,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -124,6 +136,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -142,6 +157,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -162,6 +180,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -180,6 +201,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -202,6 +226,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -221,6 +248,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -242,6 +272,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -262,6 +295,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/cuda:4.1.0-cuda11.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "ml-cuda11": {
@@ -281,6 +317,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -299,6 +338,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -51,6 +51,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.1.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "rstudio": {
@@ -72,6 +75,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -95,6 +101,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -116,6 +125,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -139,6 +151,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -160,6 +175,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -183,6 +201,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -204,6 +225,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -232,6 +256,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -257,6 +284,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -284,6 +314,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -307,6 +340,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/cuda:4.1.1-cuda11.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     "ml-cuda11": {
@@ -329,6 +365,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -350,6 +389,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/core-latest-daily.docker-bake.json
+++ b/bakefiles/core-latest-daily.docker-bake.json
@@ -29,6 +29,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "tidyverse": {
@@ -47,6 +50,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -64,6 +70,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/devel.docker-bake.json
+++ b/bakefiles/devel.docker-bake.json
@@ -30,6 +30,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "rstudio": {
@@ -47,6 +50,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -66,6 +72,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "verse": {
@@ -83,6 +92,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -102,6 +114,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "shiny": {
@@ -119,6 +134,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -138,6 +156,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "binder": {
@@ -155,6 +176,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -176,6 +200,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml": {
@@ -194,6 +221,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     },
@@ -214,6 +244,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "cuda11": {
@@ -233,6 +266,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-cuda11": {
@@ -251,6 +287,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "ml-verse-cuda11": {
@@ -268,6 +307,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -36,6 +36,9 @@
       ],
       "cache-from": [
         ""
+      ],
+      "cache-to": [
+        ""
       ]
     },
     "geospatial-dev-osgeo": {
@@ -54,6 +57,9 @@
         "linux/amd64"
       ],
       "cache-from": [
+        ""
+      ],
+      "cache-to": [
         ""
       ]
     }

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -47,6 +47,7 @@ library(stringr)
       ),
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64")),
       `cache-from` = purrr::map(value, "cache-from", .default = list("")),
+      `cache-to` = purrr::map(value, "cache-to", .default = list("")),
       base_image = map_chr(value, "FROM")
     ) %>%
     dplyr::rowwise() %>%
@@ -65,7 +66,8 @@ library(stringr)
       labels,
       tags,
       platforms,
-      `cache-from`
+      `cache-from`,
+      `cache-to`
     ) %>%
     {
       list(

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -179,6 +179,7 @@ write_stack <- function(r_version,
   template$stack[[1]]$ENV$CRAN <- cran
   template$stack[[1]]$platforms <- list("linux/amd64", "linux/arm64")
   template$stack[[1]]$`cache-from` <- list(stringr::str_c("docker.io/rocker/r-ver:", r_version))
+  template$stack[[1]]$`cache-to` <- list("inline")
 
   # rocker/rstudio
   template$stack[[2]]$FROM <- stringr::str_c("rocker/r-ver:", r_version)
@@ -339,6 +340,7 @@ write_stack <- function(r_version,
   template$stack[[12]]$ENV$R_VERSION <- r_version
   template$stack[[12]]$ENV$CRAN <- cran
   template$stack[[12]]$`cache-from` <- list(stringr::str_c("docker.io/rocker/cuda:", r_version, "-cuda11.1"))
+  template$stack[[12]]$`cache-to` <- list("inline")
 
   # rocker/ml:X.Y.Z-cuda11.1
   template$stack[[13]]$FROM <- stringr::str_c("rocker/cuda:", r_version, "-cuda11.1")

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -42,6 +42,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.0"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {
@@ -265,6 +268,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -28,6 +28,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -28,6 +28,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.2"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -28,6 +28,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.3"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -28,6 +28,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.4"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -29,6 +29,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.0.5"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -46,6 +46,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.1.0"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {
@@ -284,6 +287,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/cuda:4.1.0-cuda11.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -49,6 +49,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/r-ver:4.1.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {
@@ -329,6 +332,9 @@
       ],
       "cache-from": [
         "docker.io/rocker/cuda:4.1.1-cuda11.1"
+      ],
+      "cache-to": [
+        "inline"
       ]
     },
     {


### PR DESCRIPTION
I was wondering that builds after #227, which I intended to have the cache enabled, wouldn't reduce the build time at all (https://github.com/rocker-org/rocker-versioned2/issues/230#issuecomment-918334027), but I finally realized today that we need to explicitly export the cache...
https://github.com/moby/buildkit#export-cache

With this change, the layer that installs R this time will be cached on Docker Hub, and `rocker/r-ver` will complete the build instantly until the base image is updated.
By reusing the "install R" layer, users may also spend less time updating images with `docker pull` command.