### PR TITLE
Fix to build correctly and no warning when `RSTUDIO_VERSION` is set to latest

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -45,7 +45,7 @@ fi
 RSTUDIO_BASE_URL=https://download2.rstudio.org/server
 
 if [ -z "$RSTUDIO_VERSION_ARG" ] || [ "$RSTUDIO_VERSION_ARG" = "latest" ]; then
-    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+%2B[0-9]+" -m 1)
+    DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download-server/debian-ubuntu/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-[0-9]+" -m 1)
 elif [ "$RSTUDIO_VERSION_ARG" = "preview" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-preview%2B[0-9]+" -m 1 ||
       wget -qO - https://rstudio.com/products/rstudio/download/preview/ | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+%2B[0-9]+" -m 1)

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -103,7 +103,7 @@ if [ "$TZ" !=  "Etc/UTC" ]
 fi
 
 ## Set our dynamic variables in Renviron.site to be reflected by RStudio
-exclude_vars="HOME PASSWORD"
+exclude_vars="HOME PASSWORD RSTUDIO_VERSION"
 for file in /var/run/s6/container_environment/*
 do
   sed -i "/^${file##*/}=/d" ${R_HOME}/etc/Renviron.site


### PR DESCRIPTION
fix #261

Fix the process to get the latest version of RStudio Server.

And, update not to copy the build-time environment variable `RSTUDIO_VERSION` to the session in RStudio.
This will eliminate the warning that is displayed when the environment variable `RSTUDIO_VERSION` and the version of RStudio are different.

e.g. `rocker/rstudio:latest-daily` (`RSTUDIO_VERSION`=daily)

![image](https://user-images.githubusercontent.com/50911393/137323188-300aedaa-3e7a-4667-be54-222e5dc1f924.png)
