### PR TITLE
Fix missing "-1" from github release url in `install_pandoc.sh`

### DIFF
--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -27,7 +27,7 @@ if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
     if [ "$PANDOC_VERSION" = "default" ]; then
       PANDOC_DL_URL=$(wget -qO- https://api.github.com/repos/jgm/pandoc/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*${ARCH}\.deb")
     else
-      PANDOC_DL_URL=https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-${ARCH}.deb
+      PANDOC_DL_URL=https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-${ARCH}.deb
     fi
     wget ${PANDOC_DL_URL} -O pandoc-${ARCH}.deb
     dpkg -i pandoc-${ARCH}.deb


### PR DESCRIPTION
Hi,

this is a simple fix of the release URL which should include "-1" between the version and the architecture, at least for deb files.
https://github.com/jgm/pandoc/releases/tag/2.14.2