### PR TITLE
Fix cache exporting

### DIFF
--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -51,7 +51,7 @@
         "docker.io/rocker/r-ver:4.0.0"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {
@@ -297,7 +297,7 @@
         "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio-ubuntu18.04": {

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -28,7 +28,7 @@
         "docker.io/rocker/r-ver:4.0.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -28,7 +28,7 @@
         "docker.io/rocker/r-ver:4.0.2"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -28,7 +28,7 @@
         "docker.io/rocker/r-ver:4.0.3"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -28,7 +28,7 @@
         "docker.io/rocker/r-ver:4.0.4"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -29,7 +29,7 @@
         "docker.io/rocker/r-ver:4.0.5"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -50,7 +50,7 @@
         "docker.io/rocker/r-ver:4.1.0"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {
@@ -297,7 +297,7 @@
         "docker.io/rocker/cuda:4.1.0-cuda11.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "ml-cuda11": {

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -53,7 +53,7 @@
         "docker.io/rocker/r-ver:4.1.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "rstudio": {
@@ -342,7 +342,7 @@
         "docker.io/rocker/cuda:4.1.1-cuda11.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     "ml-cuda11": {

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -179,7 +179,7 @@ write_stack <- function(r_version,
   template$stack[[1]]$ENV$CRAN <- cran
   template$stack[[1]]$platforms <- list("linux/amd64", "linux/arm64")
   template$stack[[1]]$`cache-from` <- list(stringr::str_c("docker.io/rocker/r-ver:", r_version))
-  template$stack[[1]]$`cache-to` <- list("inline")
+  template$stack[[1]]$`cache-to` <- list("type=inline")
 
   # rocker/rstudio
   template$stack[[2]]$FROM <- stringr::str_c("rocker/r-ver:", r_version)
@@ -340,7 +340,7 @@ write_stack <- function(r_version,
   template$stack[[12]]$ENV$R_VERSION <- r_version
   template$stack[[12]]$ENV$CRAN <- cran
   template$stack[[12]]$`cache-from` <- list(stringr::str_c("docker.io/rocker/cuda:", r_version, "-cuda11.1"))
-  template$stack[[12]]$`cache-to` <- list("inline")
+  template$stack[[12]]$`cache-to` <- list("type=inline")
 
   # rocker/ml:X.Y.Z-cuda11.1
   template$stack[[13]]$FROM <- stringr::str_c("rocker/cuda:", r_version, "-cuda11.1")

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -44,7 +44,7 @@
         "docker.io/rocker/r-ver:4.0.0"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {
@@ -270,7 +270,7 @@
         "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -30,7 +30,7 @@
         "docker.io/rocker/r-ver:4.0.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -30,7 +30,7 @@
         "docker.io/rocker/r-ver:4.0.2"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -30,7 +30,7 @@
         "docker.io/rocker/r-ver:4.0.3"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -30,7 +30,7 @@
         "docker.io/rocker/r-ver:4.0.4"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -31,7 +31,7 @@
         "docker.io/rocker/r-ver:4.0.5"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -48,7 +48,7 @@
         "docker.io/rocker/r-ver:4.1.0"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {
@@ -289,7 +289,7 @@
         "docker.io/rocker/cuda:4.1.0-cuda11.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -51,7 +51,7 @@
         "docker.io/rocker/r-ver:4.1.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {
@@ -334,7 +334,7 @@
         "docker.io/rocker/cuda:4.1.1-cuda11.1"
       ],
       "cache-to": [
-        "inline"
+        "type=inline"
       ]
     },
     {


### PR DESCRIPTION
Sorry, the last build failed because of the `cache-to` part I added in #256.
Because of the missing `type=`, it seems that buildx tried to export the cache to a registry `docker.io/library/inline` and failed to build because it did not have permissions.

https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-export-build-cache-to-an-external-cache-destination---cache-to

Hopefully this PR fix will make the cache work properly this time...

An example of this specification working correctly in the past is the following, which I have done.
I didn't use the bake command, so the options are very long, but you can see that it works correctly with `cache-to type=inline`.

https://github.com/eitsupi/r-ver/runs/3631155387?check_suite_focus=true

```shell
/usr/bin/docker buildx build --build-arg VARIANT=devel --build-arg CRAN_URL=cloud.r-project.org --label org.opencontainers.image.source=eitsupi/r-ver --label org.opencontainers.image.created=2021-09-17T10:20:04Z --label org.opencontainers.image.revision=8a3b1d4ee71f1c885d22df02041254c311ccecaf --label org.opencontainers.image.description=A Docker image of R version devel --label org.opencontainers.image.title=ghcr.io/eitsupi/r-ver/builder:devel --tag ghcr.io/eitsupi/r-ver/builder:devel --target builder --platform linux/amd64,linux/arm64 --iidfile /tmp/docker-build-push-6gImcY/iidfile --metadata-file /tmp/docker-build-push-6gImcY/metadata-file --cache-from type=registry,ref=ghcr.io/eitsupi/r-ver/builder:devel --cache-to type=inline --file dockerfiles/focal.Dockerfile --push .
```