### PR TITLE
Reports: Add base image name

### DIFF
--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -71,6 +71,7 @@ df_inspect <- jsonlite::read_json(params$inspect_file) |>
     "RepoDigests",
     ImageSource = list("Config", "Labels", "org.opencontainers.image.source"),
     ImageRevision = list("Config", "Labels", "org.opencontainers.image.revision"),
+    BaseImage = list("Config", "Labels", "org.opencontainers.image.base.name"),
     CreatedTime = "Created",
     "Size",
     Env = list("Config", "Env")
@@ -81,6 +82,7 @@ df_inspect |>
     ImageID = paste0("`", ImageID, "`"),
     RepoTags = .unlist_and_enclose(RepoTags),
     RepoDigests = .unlist_and_enclose(RepoDigests),
+    BaseImage = paste0("`", BaseImage, "`"),
     Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = paste(unlist(Env), collapse = ", ")
   ) |>


### PR DESCRIPTION
Display the name of the base image in the reports to make it clear which image it was built from.

![image](https://user-images.githubusercontent.com/50911393/140525658-5454e599-a09f-4def-8b26-4579eec6b1a4.png)
