### PR TITLE
Fix `inner_join` error not to fail to knit wiki home

### DIFF
--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -51,7 +51,7 @@ df_definitions <- fs::dir_ls(
   )
 
 df_images <- fs::dir_ls(path = "reports/imagelist", glob = "*.tsv") |>
-  readr::read_tsv(col_names = FALSE) |>
+  readr::read_tsv(col_names = FALSE, lazy = FALSE) |>
   dplyr::filter(X3 != "<none>") |>
   dplyr::transmute(
     id = X1,


### PR DESCRIPTION
Updating the wiki home failed in the last report generation workflow performed.
https://github.com/rocker-org/rocker-versioned2/runs/4186805178?check_suite_focus=true#step:6:20175

This reproduces locally for me and causes R to crash with the following error in processing the `dplyr::inner_join` of this row.

https://github.com/rocker-org/rocker-versioned2/blob/53408d893258bd2ef5862209275f04ed75eb4083/build/reports/wiki_home.Rmd#L68

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  Failure to retrieve index 280 / 70
```

Given that setting `lazy=FALSE` solved the problem, it may be due to the fact that the version of the `vroom` package in `rocker/tidyverse` used in the workflow has been increased from 1.5.5 to 1.5.6.

```shell
$ diff tidyverse_4ed76ad5ea50.md 2c06c1712f9a.md
1c1
< 4ed76ad5ea50
---
> 2c06c1712f9a
3c3
< 2021-11-06 04:38:50 UTC
---
> 2021-11-12 06:47:23 UTC
11c11
< [`a382d7d`](https://github.com/rocker-org/rocker-versioned2/tree/a382d7da54d907e81efd007aa2c49f36197bbb1b),
---
> [`53408d8`](https://github.com/rocker-org/rocker-versioned2/tree/53408d893258bd2ef5862209275f04ed75eb4083),
18c18
< | ImageID       | `sha256:4ed76ad5ea50e1a3bb1746af3cf5b86612e75c224fe40f3ef3ada4e39f4f2ac2`                                                                                                                                                                                                                                                                             |
---
> | ImageID       | `sha256:2c06c1712f9ac475012ea9de5ea7685996495f7c7076152884a3ff3f47c2ac8d`                                                                                                                                                                                                                                                                             |
20c20
< | RepoDigests   | `rocker/tidyverse@sha256:ea4879b0e07e99f6eac6d35c1798fe23b0633d0694d466454f1126bde671b756`                                                                                                                                                                                                                                                            |
---
> | RepoDigests   | `rocker/tidyverse@sha256:0374c0c6c258387fdf83e6e75829fffeca1e993d32a5706e647a29d53e7ade43`                                                                                                                                                                                                                                                            |
22c22
< | ImageRevision | ea33fb2501654f06b72df42232a94a929292c7ee                                                                                                                                                                                                                                                                                                              |
---
> | ImageRevision | 53408d893258bd2ef5862209275f04ed75eb4083                                                                                                                                                                                                                                                                                                              |
24,25c24,25
< | CreatedTime   | 2021-11-01T18:18:08.940816013Z                                                                                                                                                                                                                                                                                                                        |
< | Size          | 2,378MB                                                                                                                                                                                                                                                                                                                                               |
---
> | CreatedTime   | 2021-11-12T05:35:08.797192332Z                                                                                                                                                                                                                                                                                                                        |
> | Size          | 2,747MB                                                                                                                                                                                                                                                                                                                                               |
32c32
< docker pull rocker/tidyverse@sha256:ea4879b0e07e99f6eac6d35c1798fe23b0633d0694d466454f1126bde671b756
---
> docker pull rocker/tidyverse@sha256:0374c0c6c258387fdf83e6e75829fffeca1e993d32a5706e647a29d53e7ade43
289,290c289,290
< | libpq-dev                    | 12.8-0ubuntu0.20.04.1             |
< | libpq5                       | 12.8-0ubuntu0.20.04.1             |
---
> | libpq-dev                    | 12.9-0ubuntu0.20.04.1             |
> | libpq5                       | 12.9-0ubuntu0.20.04.1             |
468c468
< | broom         | 0.7.9   |
---
> | broom         | 0.7.10  |
476,477c476,477
< | cpp11         | 0.4.0   |
< | crayon        | 1.4.1   |
---
> | cpp11         | 0.4.1   |
> | crayon        | 1.4.2   |
489a490
> | duckdb        | 0.3.0   |
500c501
< | gert          | 1.4.1   |
---
> | gert          | 1.4.3   |
504c505
< | glue          | 1.4.2   |
---
> | glue          | 1.5.0   |
565c566
< | sessioninfo   | 1.1.1   |
---
> | sessioninfo   | 1.2.1   |
570c571
< | tibble        | 3.1.5   |
---
> | tibble        | 3.1.6   |
574c575
< | tinytex       | 0.34    |
---
> | tinytex       | 0.35    |
578c579
< | uuid          | 1.0-2   |
---
> | uuid          | 1.0-3   |
581c582
< | vroom         | 1.5.5   |
---
> | vroom         | 1.5.6   |
585c586
< | xfun          | 0.27    |
---
> | xfun          | 0.28    |
```