### PR TITLE
Update RStudio Server installer url and bump RStudio Server to 2021.09.1+372 in R4.1.2 images

### DIFF
--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -85,7 +85,7 @@ library(gert)
   is_available <- glue::glue(
     "https://download2.rstudio.org/server/{os_ver}/amd64/rstudio-server-{rstudio_version}-amd64.deb"
   ) |>
-    stringr::str_replace_all("\\+", "%2B") |>
+    stringr::str_replace_all("\\+", "-") |>
     httr::HEAD() |>
     httr::http_status() |>
     (function(x) purrr::pluck(x, "category") == "Success")()

--- a/dockerfiles/ml-cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.1.2.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/ml-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-cuda11_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/ml_4.1.2.Dockerfile
+++ b/dockerfiles/ml_4.1.2.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
 ENV TENSORFLOW_VERSION=gpu

--- a/dockerfiles/ml_devel.Dockerfile
+++ b/dockerfiles/ml_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
 ENV TENSORFLOW_VERSION=gpu

--- a/dockerfiles/rstudio_4.1.2.Dockerfile
+++ b/dockerfiles/rstudio_4.1.2.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/dockerfiles/rstudio_devel.Dockerfile
+++ b/dockerfiles/rstudio_devel.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2021.09.0+351
+ENV RSTUDIO_VERSION=2021.09.1+372
 ENV DEFAULT_USER=rstudio
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -54,7 +54,7 @@ elif [ "$RSTUDIO_VERSION_ARG" = "daily" ]; then
     DOWNLOAD_VERSION=$(wget -qO - https://dailies.rstudio.com/rstudio/latest/index.json | grep -oP "(?<=rstudio-server-)[0-9]+\.[0-9]+\.[0-9]+-daily-[0-9]+(?=-amd64.deb)" -m 1)
     RSTUDIO_BASE_URL=https://s3.amazonaws.com/rstudio-ide-build/server
 else
-    DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG/"+"/"%2B"}
+    DOWNLOAD_VERSION=${RSTUDIO_VERSION_ARG/"+"/"-"}
 fi
 
 ## UBUNTU_VERSION is not generally valid: only works for xenial and bionic, not other releases,

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -64,7 +64,7 @@
       "FROM": "rocker/r-ver:4.1.2",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
@@ -253,7 +253,7 @@
       "FROM": "rocker/cuda:4.1.2",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
         "TENSORFLOW_VERSION": "gpu",
@@ -354,7 +354,7 @@
       "FROM": "rocker/cuda:4.1.2-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -48,7 +48,7 @@
       "FROM": "rocker/r-ver:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
@@ -183,7 +183,7 @@
       "FROM": "rocker/cuda:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
         "TENSORFLOW_VERSION": "gpu",
@@ -266,7 +266,7 @@
       "FROM": "rocker/cuda:devel-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2021.09.0+351",
+        "RSTUDIO_VERSION": "2021.09.1+372",
         "DEFAULT_USER": "rstudio",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },


### PR DESCRIPTION
I noticed that even though a new version of RStudio (`2021.09.1+372`) has been released, container definition files are not being automatically updated by the build system.
The reason was that the URL for `2021.09.1+372`'s installer did not have the `+` replaced with `%2B` that was used for `2021.09.0+351`'s (#250), but the `+` replaced with `-` (#265).