### PR TITLE
Some minor updates to Dockerfiles and install scripts

### DIFF
--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -96,8 +96,8 @@ library(gert)
 .latest_ctan_url <- function(date) {
   url <- dplyr::if_else(
     is.na(date),
-    "http://mirror.ctan.org/systems/texlive/tlnet",
-    stringr::str_c("http://www.texlive.info/tlnet-archive/", format(date, "%Y/%m/%d"), "/tlnet")
+    "https://mirror.ctan.org/systems/texlive/tlnet",
+    stringr::str_c("https://www.texlive.info/tlnet-archive/", format(date, "%Y/%m/%d"), "/tlnet")
   )
 
   return(url)

--- a/dockerfiles/ml-verse-cuda11_4.0.3.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.0.3.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/02/14/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/02/14/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse-cuda11_4.0.4.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.0.4.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/03/30/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/03/30/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse-cuda11_4.0.5.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.0.5.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/05/17/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/05/17/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.0.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/08/09/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/10/31/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_devel.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse_4.0.0.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/05/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/06/05/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.0.1.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/21/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/06/21/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.0.2.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/10/07/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/10/07/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.0.3.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.3.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/02/14/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/02/14/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.0.4.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.4.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/03/30/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/03/30/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.0.5.Dockerfile
+++ b/dockerfiles/ml-verse_4.0.5.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/05/17/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/05/17/tlnet
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.1.0.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/08/09/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse_4.1.1.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/10/31/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse_4.1.2.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/ml-verse_devel.Dockerfile
+++ b/dockerfiles/ml-verse_devel.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse-ubuntu18.04_4.0.0.Dockerfile
+++ b/dockerfiles/verse-ubuntu18.04_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/05/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/06/05/tlnet
 ENV PATH=/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.0.Dockerfile
+++ b/dockerfiles/verse_4.0.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/05/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/06/05/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.1.Dockerfile
+++ b/dockerfiles/verse_4.0.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/06/21/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/06/21/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.2.Dockerfile
+++ b/dockerfiles/verse_4.0.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2020/10/07/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2020/10/07/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.3.Dockerfile
+++ b/dockerfiles/verse_4.0.3.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/02/14/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/02/14/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.4.Dockerfile
+++ b/dockerfiles/verse_4.0.4.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/03/30/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/03/30/tlnet
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.0.5.Dockerfile
+++ b/dockerfiles/verse_4.0.5.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/05/17/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/05/17/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/verse_4.1.0.Dockerfile
+++ b/dockerfiles/verse_4.1.0.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/08/09/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 ENV QUARTO_VERSION=latest
 

--- a/dockerfiles/verse_4.1.1.Dockerfile
+++ b/dockerfiles/verse_4.1.1.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://www.texlive.info/tlnet-archive/2021/10/31/tlnet
+ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 ENV QUARTO_VERSION=latest
 

--- a/dockerfiles/verse_4.1.2.Dockerfile
+++ b/dockerfiles/verse_4.1.2.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 ENV QUARTO_VERSION=latest
 

--- a/dockerfiles/verse_devel.Dockerfile
+++ b/dockerfiles/verse_devel.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 ENV QUARTO_VERSION=latest
 

--- a/dockerfiles/verse_latest-daily.Dockerfile
+++ b/dockerfiles/verse_latest-daily.Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.vendor="Rocker Project" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
-ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/x86_64-linux
 ENV QUARTO_VERSION=latest
 

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if id -u "${user}" >/dev/null 2>&1; then
     echo 'rstudio user already exists'

--- a/scripts/install_cuda-10.1.sh
+++ b/scripts/install_cuda-10.1.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 apt-get update && apt-get install -y --no-install-recommends \
 gnupg2 curl ca-certificates && \

--- a/scripts/install_cuda-11.1.sh
+++ b/scripts/install_cuda-11.1.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates && \

--- a/scripts/install_gdal_source.sh
+++ b/scripts/install_gdal_source.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 PROJ_VERSION=7.2.0
 GDAL_VERSION=3.2.0

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -19,7 +19,7 @@ apt-get update
 apt-get install -y --no-install-recommends \
     sudo \
     gdebi-core \
-    libcurl4-gnutls-dev \
+    libcurl4-openssl-dev \
     libcairo2-dev \
     libxt-dev \
     xtail \

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo 'selected_scheme scheme-infraonly
 TEXDIR /usr/local/texlive

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -11,7 +11,7 @@ TEXMFVAR /opt/texlive/texmf-var
 option_doc 0
 option_src 0' > /tmp/texlive-profile.txt
 
-CTAN_REPO=${CTAN_REPO:-http://mirror.ctan.org/systems/texlive/tlnet}
+CTAN_REPO=${CTAN_REPO:-https://mirror.ctan.org/systems/texlive/tlnet}
 export PATH=$PATH:/usr/local/texlive/bin/x86_64-linux/:/usr/local/texlive/bin/aarch64-linux/
 
 mkdir -p /opt/texlive

--- a/scripts/install_tf1_cuda_10_0.sh
+++ b/scripts/install_tf1_cuda_10_0.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Tensorflow 1.x is required for numerous projects.  
 # Even the most recent of the 1.x, 1.15.5 is compatible only 

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 ## https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2/
 

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -91,7 +91,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.0",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/06/05/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/06/05/tlnet",
         "PATH": "/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -237,7 +237,7 @@
       },
       "FROM": "rocker/ml:4.0.0",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/06/05/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/06/05/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -318,7 +318,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.0-ubuntu18.04",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/06/05/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/06/05/tlnet",
         "PATH": "/opt/texlive/bin/x86_64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -77,7 +77,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/06/21/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/06/21/tlnet",
         "PATH": "/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -223,7 +223,7 @@
       },
       "FROM": "rocker/ml:4.0.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/06/21/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/06/21/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -77,7 +77,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.2",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/10/07/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/10/07/tlnet",
         "PATH": "/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -223,7 +223,7 @@
       },
       "FROM": "rocker/ml:4.0.2",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2020/10/07/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2020/10/07/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -77,7 +77,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.3",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/02/14/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/02/14/tlnet",
         "PATH": "/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -223,7 +223,7 @@
       },
       "FROM": "rocker/ml:4.0.3",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/02/14/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/02/14/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -305,7 +305,7 @@
         "/rocker_scripts/install_geospatial.sh"
       ],
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/02/14/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/02/14/tlnet"
       }
     }
   ]

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -77,7 +77,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.4",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/03/30/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/03/30/tlnet",
         "PATH": "/usr/local/texlive/bin/x86_64-linux:$PATH"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -223,7 +223,7 @@
       },
       "FROM": "rocker/ml:4.0.4",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/03/30/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/03/30/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -305,7 +305,7 @@
         "/rocker_scripts/install_geospatial.sh"
       ],
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/03/30/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/03/30/tlnet"
       }
     }
   ]

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -80,7 +80,7 @@
       },
       "FROM": "rocker/tidyverse:4.0.5",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/05/17/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/05/17/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux"
       },
       "RUN": "/rocker_scripts/install_verse.sh",
@@ -236,7 +236,7 @@
       },
       "FROM": "rocker/ml:4.0.5",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/05/17/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/05/17/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -321,7 +321,7 @@
         "/rocker_scripts/install_geospatial.sh"
       ],
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/05/17/tlnet"
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/05/17/tlnet"
       }
     }
   ]

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -95,7 +95,7 @@
       },
       "FROM": "rocker/tidyverse:4.1.0",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux",
         "QUARTO_VERSION": "latest"
       },
@@ -244,7 +244,7 @@
       },
       "FROM": "rocker/ml:4.1.0",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [
@@ -329,7 +329,7 @@
       },
       "FROM": "rocker/ml:4.1.0-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -95,7 +95,7 @@
       },
       "FROM": "rocker/tidyverse:4.1.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux",
         "QUARTO_VERSION": "latest"
       },
@@ -244,7 +244,7 @@
       },
       "FROM": "rocker/ml:4.1.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [
@@ -329,7 +329,7 @@
       },
       "FROM": "rocker/ml:4.1.1-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "http://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
+        "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -104,7 +104,7 @@
       },
       "FROM": "rocker/tidyverse:4.1.2",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux",
         "QUARTO_VERSION": "latest"
       },
@@ -286,7 +286,7 @@
       },
       "FROM": "rocker/ml:4.1.2",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [
@@ -380,7 +380,7 @@
       },
       "FROM": "rocker/ml:4.1.2-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [

--- a/stacks/core-latest-daily.json
+++ b/stacks/core-latest-daily.json
@@ -53,7 +53,7 @@
       },
       "FROM": "rocker/tidyverse:latest-daily",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux",
         "QUARTO_VERSION": "latest"
       },

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -76,7 +76,7 @@
       },
       "FROM": "rocker/tidyverse:devel",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/x86_64-linux",
         "QUARTO_VERSION": "latest"
       },
@@ -210,7 +210,7 @@
       },
       "FROM": "rocker/ml:devel",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [
@@ -289,7 +289,7 @@
       },
       "FROM": "rocker/ml:devel-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "http://mirror.ctan.org/systems/texlive/tlnet",
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
         "QUARTO_VERSION": "latest"
       },
       "RUN": [


### PR DESCRIPTION
I'm submitting this because I found several small improvements that have little impact on the behavior of the container.

1. CTAN mirrors are HTTPS enabled.
2. Some scripts are missing `set -e` and may succeed in the build even if the installation fails. Like that:  <img width="806" alt="ml-verse_a68e3defd062" src="https://user-images.githubusercontent.com/50911393/142158922-756653aa-a604-448e-8d46-9d2f5039bf5a.png">  
It seems that the installation of wgrib2 failed because wget failed 20 retries, but the image was built as is and pushed to DockerHub.
3. Switch `libcurl4-gnutls-dev` to `libcurl4-openssl-dev` in `install_shiny_server.sh`, as described in https://github.com/rocker-org/rocker-versioned2/pull/156#issue-877264275.  
`rocker/shiny-verse` images has `libcurl4-openssl-dev` installed, but it doesn't seem to have any problems, so we can expect that replacing `libcurl4-gnutls-dev` in `install_shiny_server.sh` with `libcurl4-openssl-dev` will not cause any problems.
