### PR TITLE
Proof-of-concept for code-server based interface

### DIFF
--- a/experimental/entrypoint.sh
+++ b/experimental/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+# We do this first to ensure sudo works below when renaming the user.
+# Otherwise the current container UID may not exist in the passwd database.
+eval "$(fixuid -q)"
+
+if [ "${DOCKER_USER-}" ]; then
+  USER="$DOCKER_USER"
+  if [ "$DOCKER_USER" != "$(whoami)" ]; then
+    echo "$DOCKER_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/nopasswd > /dev/null
+    # Unfortunately we cannot change $HOME as we cannot move any bind mounts
+    # nor can we bind mount $HOME into a new home as that requires a privileged container.
+    sudo usermod --login "$DOCKER_USER" coder
+    sudo groupmod -n "$DOCKER_USER" coder
+
+    sudo sed -i "/coder/d" /etc/sudoers.d/nopasswd
+  fi
+fi
+
+dumb-init /usr/bin/code-server "$@"

--- a/experimental/entrypoint.sh
+++ b/experimental/entrypoint.sh
@@ -11,10 +11,10 @@ if [ "${DOCKER_USER-}" ]; then
     echo "$DOCKER_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/nopasswd > /dev/null
     # Unfortunately we cannot change $HOME as we cannot move any bind mounts
     # nor can we bind mount $HOME into a new home as that requires a privileged container.
-    sudo usermod --login "$DOCKER_USER" coder
-    sudo groupmod -n "$DOCKER_USER" coder
+    sudo usermod --login "$DOCKER_USER" rocker
+    sudo groupmod -n "$DOCKER_USER" rocker
 
-    sudo sed -i "/coder/d" /etc/sudoers.d/nopasswd
+    sudo sed -i "/rocker/d" /etc/sudoers.d/nopasswd
   fi
 fi
 

--- a/experimental/scripts/configure_vscode.sh
+++ b/experimental/scripts/configure_vscode.sh
@@ -1,0 +1,13 @@
+
+## Runs as user 
+
+install2.r languageserver lintr styler profvis httpgd
+sudo pip install radian
+
+## unfortunately these don't run and complete, but instead tries to bring up code-server
+#code-server install Ikuyadeu.r
+#code-server install RDebugger.r-debugger
+
+echo "options(vsc.use_httpgd = TRUE)" >> ~/.Rprofile
+
+

--- a/experimental/scripts/install_vscode.sh
+++ b/experimental/scripts/install_vscode.sh
@@ -13,6 +13,7 @@ apt-get update \
     nano \
     git \
     procps \
+    pandoc \
     openssh-client \
     sudo \
     vim.tiny \

--- a/experimental/scripts/install_vscode.sh
+++ b/experimental/scripts/install_vscode.sh
@@ -2,25 +2,48 @@
 
 set -e
 
+apt-get update \
+ && apt-get install -y \
+    curl \
+    dumb-init \
+    zsh \
+    htop \
+    locales \
+    man \
+    nano \
+    git \
+    procps \
+    openssh-client \
+    sudo \
+    vim.tiny \
+    lsb-release \
+    tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+DEFAULT_USER=${1:-${DEFAULT_USER:-rocker}}
+adduser --gecos '' --disabled-password ${DEFAULT_USER} && \
+  echo "${DEFAULT_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+addgroup ${DEFAULT_USER} staff
+
+## User name is always ${DEFAULT_USER} even when run with different $(id -u):$(id -g)
+## allow user name to be set with DOCKER_USER at runtime 
+ARCH="$(dpkg --print-architecture)" && \
+    curl -fsSL "https://github.com/boxboat/fixuid/releases/download/v0.5/fixuid-0.5-linux-$ARCH.tar.gz" | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: ${DEFAULT_USER}\ngroup: ${DEFAULT_USER}\n" > /etc/fixuid/config.yml
+
+
 ## Consider ability to detect latest version
 VSCODE_VERSION=3.12.0
 
 curl -fOL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 dpkg -i code-server_${VSCODE_VERSION}_amd64.deb
 
-## Need to configure non-root user for RStudio
-DEFAULT_USER=${1:-${DEFAULT_USER:-rocker}}
-useradd -s /bin/bash -m $DEFAULT_USER
-echo "${DEFAULT_USER}:${DEFAULT_USER}" | chpasswd
-addgroup ${DEFAULT_USER} staff
-addgroup ${DEFAULT_USER} sudo
-
 ## configure git not to request password each time
 git config --system credential.helper 'cache --timeout=3600'
 git config --system push.default simple
 
 
-
-## Consider easy-to-use OAuth configurations for codeserver:
-# https://www.pomerium.io/guides/code-server.html
 

--- a/experimental/scripts/install_vscode.sh
+++ b/experimental/scripts/install_vscode.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+## Consider ability to detect latest version
+VSCODE_VERSION=3.12.0
+
+curl -fOL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+dpkg -i code-server_${VSCODE_VERSION}_amd64.deb
+
+## Need to configure non-root user for RStudio
+DEFAULT_USER=${1:-${DEFAULT_USER:-rocker}}
+useradd -s /bin/bash -m $DEFAULT_USER
+echo "${DEFAULT_USER}:${DEFAULT_USER}" | chpasswd
+addgroup ${DEFAULT_USER} staff
+addgroup ${DEFAULT_USER} sudo
+
+## configure git not to request password each time
+git config --system credential.helper 'cache --timeout=3600'
+git config --system push.default simple
+
+
+
+## Consider easy-to-use OAuth configurations for codeserver:
+# https://www.pomerium.io/guides/code-server.html
+

--- a/experimental/vscode-notes.Rmd
+++ b/experimental/vscode-notes.Rmd
@@ -1,0 +1,5 @@
+See Dockerfile: 
+
+https://github.com/cdr/code-server/blob/main/ci/release-image/Dockerfile
+
+

--- a/experimental/vscode.Dockerfile
+++ b/experimental/vscode.Dockerfile
@@ -1,0 +1,41 @@
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
+      org.opencontainers.image.source="https://github.com/rocker-org/rocker-versioned2" \
+      org.opencontainers.image.vendor="Rocker Project" \
+      org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
+
+ENV R_VERSION=4.1.2
+ENV TERM=xterm
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV R_HOME=/usr/local/lib/R
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
+ENV TZ=Etc/UTC
+ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf
+ENV WORKON_HOME=/opt/venv
+ENV PYTHON_VENV_PATH=/opt/venv/reticulate
+ENV PYTHON_CONFIGURE_OPTS=--enable-shared
+ENV RETICULATE_AUTOCONFIGURE=0
+ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
+ENV CTAN_REPO=http://mirror.ctan.org/systems/texlive/tlnet
+
+COPY scripts /rocker_scripts
+RUN /rocker_scripts/install_R.sh
+RUN /rocker_scripts/config_R_cuda.sh
+RUN /rocker_scripts/install_python.sh
+RUN /rocker_scripts/install_tidyverse.sh
+RUN /rocker_scripts/install_verse.sh
+RUN /rocker_scripts/install_geospatial.sh
+
+COPY experimental/scripts /rocker_scripts/experimental
+RUN /rocker_scripts/experimental/install_vscode.sh
+
+EXPOSE 8080
+
+USER rocker
+
+RUN /rocker_scripts/experimental/configure_vscode.sh
+
+CMD code-server --bind-addr 0.0.0.0:8080
+

--- a/experimental/vscode.Dockerfile
+++ b/experimental/vscode.Dockerfile
@@ -30,12 +30,15 @@ RUN /rocker_scripts/install_geospatial.sh
 
 COPY experimental/scripts /rocker_scripts/experimental
 RUN /rocker_scripts/experimental/install_vscode.sh
+COPY experimental/entrypoint.sh /usr/bin/entrypoint.sh
 
 EXPOSE 8080
+# This way, if someone sets $DOCKER_USER, docker-exec will still work as
+# the uid will remain the same. note: only relevant if -u isn't passed to
+# docker-run.
+USER 1000
+ENV USER=rocker
+WORKDIR /home/rocker
+ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."]
 
-USER rocker
-
-RUN /rocker_scripts/experimental/configure_vscode.sh
-
-CMD code-server --bind-addr 0.0.0.0:8080
 

--- a/scripts/dev_osgeo.sh
+++ b/scripts/dev_osgeo.sh
@@ -41,7 +41,7 @@ apt-get install -y \
 
 locale-gen en_US.UTF-8
 
-PROJ_VERSION=${PROJ_VERSION:-7.2.0}
+PROJ_VERSION=${PROJ_VERSION:-8.2.0}
 LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
@@ -72,7 +72,7 @@ cd proj-${PROJ_VERSION} \
 # GDAL:
 
 # https://download.osgeo.org/gdal/
-GDAL_VERSION=${GDAL_VERSION:-3.2.0}
+GDAL_VERSION=${GDAL_VERSION:-3.4.0}
 GDAL_VERSION_NAME=${GDAL_VERSION}
 
 wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION_NAME}.tar.gz \
@@ -95,7 +95,7 @@ wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION_NAME}.ta
 #  && ldconfig
 
 # GEOS:
-GEOS_VERSION=${GEOS_VERSION:-3.8.1}
+GEOS_VERSION=${GEOS_VERSION:-3.9.2}
 
 wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
   && bzip2 -d geos-*bz2 \


### PR DESCRIPTION
A proof-of-concept to enable users to swap in https://github.com/cdr/code-server as a possible alternative to RStudio Server.

Motivation: Rocker instances with RStudio built-in provide a natural/convenient way for users to interact with the container on a remote or local host through it's web-browser interface.  `code-server` provides a similar browser-based environment, only built upon Visual Studio instead.  In addition to just supporting the option of a different IDE interface that may be preferable to some users, the `code-server` approach may offer a few benefits to some of the long-standing challenges we've had, such as:

- running the container as non-root user (particularly for podman and other docker-based options that require this)
- built-in support for jupyter notebooks (our binder builds have some unresolved issues)
- allowing arbitrary number of tabs to be open to different (or the same) projects running in the same instance (no need to use different browsers etc)
- less coupling between the R session / active project and the editor and other IDE features (i.e. can restart the R session or switch projects without interrupting the active terminal, though maybe using a terminal multiplexer in RStudio is sufficient for that)
- some convenient integrations for existing OAuth authentication options, e.g. https://www.pomerium.io/guides/code-server.html

While this would provide  access to Visual Studio extensions, themes, and IDE features, note that code-server does not support the non-open-source extensions found in Visual Studio, such as LiveShare or CoPilot.  


