### PR TITLE
Set a random password as default password of RStudio Server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # News
 
+## 2021-12
+
+### Changes in pre-built images
+
+- In the newly built images, the default password for RStudio Server will be randomly generated when the server is started. ([#298](https://github.com/rocker-org/rocker-versioned2/pull/298))
+
 ## 2021-11
 
 ### Changes in rocker_scripts

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -19,6 +19,7 @@ apt-get install -y --no-install-recommends \
     psmisc \
     procps \
     python-setuptools \
+    pwgen \
     sudo \
     wget
 

--- a/scripts/userconf.sh
+++ b/scripts/userconf.sh
@@ -3,7 +3,6 @@
 ## Set defaults for environmental variables in case they are undefined
 DEFAULT_USER=${DEFAULT_USER:-rstudio}
 USER=${USER:=${DEFAULT_USER}}
-PASSWORD=${PASSWORD:=rstudio}
 USERID=${USERID:=1000}
 GROUPID=${GROUPID:=1000}
 ROOT=${ROOT:=FALSE}
@@ -24,15 +23,16 @@ fi
 if grep --quiet "auth-none=1" /etc/rstudio/rserver.conf
 then
 	echo "Skipping authentication as requested"
-elif [ "$PASSWORD" == "rstudio" ]
+elif [ -z "$PASSWORD" ]
 then
+    PASSWORD=$(pwgen 16 1)
     printf "\n\n"
     tput bold
-    printf "\e[31mERROR\e[39m: You must set a unique PASSWORD (not 'rstudio') first! e.g. run with:\n"
+    printf "The password is set to \e[31m%s\e[39m\n" "$PASSWORD"
+    printf "If you want to set your own password, set the PASSWORD environment variable. e.g. run with:\n"
     printf "docker run -e PASSWORD=\e[92m<YOUR_PASS>\e[39m -p 8787:8787 rocker/rstudio\n"
     tput sgr0
     printf "\n\n"
-    exit 1
 fi
 
 if [ "$USERID" -lt 1000 ]


### PR DESCRIPTION
Close #294, close #237

If the environment variable `PASSWORD` is not set, the RStudio user's password will be automatically generated and set when the `/init` command is executed.

![image](https://user-images.githubusercontent.com/50911393/143885275-73150725-ca1b-4cbb-9b8c-f87c96abb64e.png)

**ToDo**

- [ ] Update docs.
  - [x] NEWS
  - [ ] The Rocker Project website https://www.rocker-project.org/use/managing_users/
  - [ ] DockerHub https://hub.docker.com/r/rocker/rstudio
