### PR TITLE
Causes automatic update workflows to fail if RSPM becomes unavailable

### DIFF
--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   createPullRequest:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: rocker/tidyverse:latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![license](https://img.shields.io/badge/license-GPLv2-blue.svg)](https://opensource.org/licenses/GPL-2.0)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Update container definition files](https://github.com/rocker-org/rocker-versioned2/actions/workflows/dockerfiles.yml/badge.svg)](https://github.com/rocker-org/rocker-versioned2/actions/workflows/dockerfiles.yml)
 [![Build & Push Core images](https://github.com/rocker-org/rocker-versioned2/actions/workflows/core.yml/badge.svg)](https://github.com/rocker-org/rocker-versioned2/actions/workflows/core.yml)
 [![Build & Push R devel images and RStudio daily build images](https://github.com/rocker-org/rocker-versioned2/actions/workflows/devel.yml/badge.svg)](https://github.com/rocker-org/rocker-versioned2/actions/workflows/devel.yml)
 


### PR DESCRIPTION
Related to #299.

The workflow for automatically updating Dockerfile etc. communicates with [RStudio Public Package Manager](https://packagemanager.rstudio.com/) to explore available URLs.
If RSPM is not accessible, as it is today, the execution time of the workflow will be very long, so I will change the workflow to stop and error by setting a time limit.
And, add a badge to README.md so that we can check if there are any errors easily.

![image](https://user-images.githubusercontent.com/50911393/144415000-dd60f6fc-d1c9-4f7d-8053-2b770c1ac047.png)
