### PR TITLE
Add a new GitHub Actions workflow to update DockerHub descriptions

### DIFF
--- a/.github/workflows/descriptions.yml
+++ b/.github/workflows/descriptions.yml
@@ -1,0 +1,29 @@
+name: Update Docker Hub Description
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - descriptions/*.md
+  workflow_dispatch:
+
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: cuda
+            short-description: NVIDIA CUDA libraries added to Rocker image.
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker Hub Description
+      uses: peter-evans/dockerhub-description@v2
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: rocker/${{ matrix.image }}
+        short-description: ${{ matrix.short-description }}
+        readme-filepath: ./descriptions/${{ matrix.image }}.md

--- a/descriptions/README.md
+++ b/descriptions/README.md
@@ -1,0 +1,3 @@
+# Pre-built images' descriptions
+
+Markdown files in this directory are descriptions of the pre-built images that are displayed on DockerHub.

--- a/descriptions/cuda.md
+++ b/descriptions/cuda.md
@@ -1,0 +1,75 @@
+# Rocker stack for Machine Learning in R 
+
+This repository contains images for machine learning and GPU-based computation in R.  **EDIT** Dockerfiles are now built in modular build system at https://github.com/rocker-org/rocker-versioned2 .  This repo remains for documentation around the ML part of the stack.  
+
+
+
+
+The dependency stack looks like so: 
+
+```
+-| rocker/cuda
+  -| rocker/ml
+    -| rocker/ml-verse
+```
+
+All three are CUDA compatible and will optionally take R version tags (`rocker/ml:4.0.5`) with the option of additional trailing CUDA version tag (e.g. `rocker/ml:4.0.5-cuda10.1`). 
+
+
+## Quick start
+
+**Note: GPU use requires [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)** runtime to run!  
+
+Run a bash shell or R command line:
+
+```
+# CPU-only
+docker run --rm -ti rocker/ml R
+# Machines with nvidia-docker and GPU support
+docker run --gpus all --rm -ti rocker/ml R
+```
+
+Or run in RStudio instance:
+
+```
+docker run --gpus all -e PASSWORD=mu -p 8787:8787 rocker/ml
+```
+
+
+## Tags
+
+See [current `ml` tags](https://hub.docker.com/r/rocker/ml/tags?page=1&ordering=last_updated)
+See [current `ml-verse` tags](https://hub.docker.com/r/rocker/ml-verse/tags?page=1&ordering=last_updated)
+
+
+## Python versions and virtualenvs
+
+The ML images configure a default python virtualenv using the Ubuntu system python (3.8.5 for current Ubuntu 20.04 LTS), see [install_python.sh](https://github.com/rocker-org/rocker-versioned2/blob/master/scripts/install_python.sh).  This virtualenv is user-writable and the default detected by `reticulate` (using `WORKON_HOME` and `PYTHON_VENV_PATH` variables).
+
+Images also configure [pipenv](https://github.com/pypa/pipenv) with [pyenv](https://github.com/pyenv/pyenv) by default.  This makes it very easy to manage projects that require specific versions of Python as well as specific python modules.  For instance, a project using the popular `[greta](https://greta-stats.org/)` package for GPU-accelerated Bayesian inference needs Tensorflow 1.x, which requires Python <= 3.7, might do:
+
+```bash
+pipenv --python 3.7
+```
+
+In the bash terminal to set up a pipenv-managed virtualenv in the working directory using Python 3.7.  Then in R we can activate this virtualenv
+
+```r
+venv <- system("pipenv --venv", inter = TRUE)
+reticulate::use_virtualenv(venv, required = TRUE)
+```
+
+We can now install tensorflow version needed, e.g.
+
+```r
+install.packages("tensorflow")
+tensorflow::install_tensorflow(version="1.14.0-gpu", extra_packages="tensorflow-probability==0.7.0")
+```
+
+
+
+## Notes
+
+All images are based on the current Ubuntu LTS (ubuntu 20.04) and based on the official [NVIDIA CUDA docker build recipes](https://gitlab.com/nvidia/container-images/cuda/)
+
+**PLEASE NOTE**: older images, `rocker/ml-gpu`, `rocker/tensorflow` and `rocker/tensorflow-gpu`, built with cuda 9.0, are deprecated and no longer supported.  

--- a/descriptions/cuda.md
+++ b/descriptions/cuda.md
@@ -1,6 +1,8 @@
 # Rocker stack for Machine Learning in R 
 
-This repository contains images for machine learning and GPU-based computation in R.  **EDIT** Dockerfiles are now built in modular build system at https://github.com/rocker-org/rocker-versioned2 .  This repo remains for documentation around the ML part of the stack.  
+Docker images for machine learning and GPU-based computation in R.
+
+Dockerfiles are built in modular build system at https://github.com/rocker-org/rocker-versioned2.
 
 
 
@@ -15,6 +17,7 @@ The dependency stack looks like so:
 
 All three are CUDA compatible and will optionally take R version tags (`rocker/ml:4.0.5`) with the option of additional trailing CUDA version tag (e.g. `rocker/ml:4.0.5-cuda10.1`). 
 
+See https://github.com/rocker-org/rocker-versioned2/wiki for details of available tags and images.
 
 ## Quick start
 

--- a/descriptions/cuda.md
+++ b/descriptions/cuda.md
@@ -1,31 +1,28 @@
-# Rocker stack for Machine Learning in R 
+# Rocker stack for Machine Learning in R
 
-Docker images for machine learning and GPU-based computation in R.
+`rocker/cuda`, `rocker/ml`, and `rocker/ml-verse` are Docker images for machine learning and GPU-based computation in R.
 
-Dockerfiles are built in modular build system at https://github.com/rocker-org/rocker-versioned2.
+These images are built in modular build system at <https://github.com/rocker-org/rocker-versioned2>.
 
+The dependency stack looks like so:
 
-
-
-The dependency stack looks like so: 
-
-```
+```txt
 -| rocker/cuda
   -| rocker/ml
     -| rocker/ml-verse
 ```
 
-All three are CUDA compatible and will optionally take R version tags (`rocker/ml:4.0.5`) with the option of additional trailing CUDA version tag (e.g. `rocker/ml:4.0.5-cuda10.1`). 
+All three are CUDA compatible and will optionally take R version tags (`rocker/ml:4.0.5`) with the option of additional trailing CUDA version tag (e.g. `rocker/ml:4.0.5-cuda10.1`).
 
-See https://github.com/rocker-org/rocker-versioned2/wiki for details of available tags and images.
+See <https://github.com/rocker-org/rocker-versioned2/wiki> for details of available tags and images.
 
 ## Quick start
 
-**Note: GPU use requires [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)** runtime to run!  
+**Note: GPU use requires [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/)** runtime to run!
 
 Run a bash shell or R command line:
 
-```
+```shell
 # CPU-only
 docker run --rm -ti rocker/ml R
 # Machines with nvidia-docker and GPU support
@@ -34,16 +31,14 @@ docker run --gpus all --rm -ti rocker/ml R
 
 Or run in RStudio instance:
 
-```
+```shell
 docker run --gpus all -e PASSWORD=mu -p 8787:8787 rocker/ml
 ```
-
 
 ## Tags
 
 See [current `ml` tags](https://hub.docker.com/r/rocker/ml/tags?page=1&ordering=last_updated)
 See [current `ml-verse` tags](https://hub.docker.com/r/rocker/ml-verse/tags?page=1&ordering=last_updated)
-
 
 ## Python versions and virtualenvs
 
@@ -69,10 +64,8 @@ install.packages("tensorflow")
 tensorflow::install_tensorflow(version="1.14.0-gpu", extra_packages="tensorflow-probability==0.7.0")
 ```
 
-
-
 ## Notes
 
 All images are based on the current Ubuntu LTS (ubuntu 20.04) and based on the official [NVIDIA CUDA docker build recipes](https://gitlab.com/nvidia/container-images/cuda/)
 
-**PLEASE NOTE**: older images, `rocker/ml-gpu`, `rocker/tensorflow` and `rocker/tensorflow-gpu`, built with cuda 9.0, are deprecated and no longer supported.  
+**PLEASE NOTE**: older images, `rocker/ml-gpu`, `rocker/tensorflow` and `rocker/tensorflow-gpu`, built with cuda 9.0, are deprecated and no longer supported.


### PR DESCRIPTION
Related to #191

Add a workflow to update the description on DockerHub with GitHub Actions.
It allows documents located in different repositories to be aggregated into this repository.
If you are able to consolidate the documentation, I recommend archiving the old GitHub repository to avoid confusion.

Since we don't know if it will work properly, I am first targeting only `rocker/cuda`, which is considered to be the least affected (since it was not used until a few months ago).

Current appearance https://hub.docker.com/r/rocker/cuda

![image](https://user-images.githubusercontent.com/50911393/145427945-b4b6c3ea-0ead-4e37-a175-b87da9917f62.png)