### PR TITLE
Require at least v2 of jupyter-rsession-proxy

### DIFF
--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -23,7 +23,7 @@ echo "export PATH=${PATH}" >> ${WORKDIR}/.profile
 su ${NB_USER}
 cd ${WORKDIR}
 python3 -m venv ${PYTHON_VENV_PATH}
-pip3 install --no-cache-dir jupyter-rsession-proxy
+pip3 install --no-cache-dir jupyter-rsession-proxy>=2.0
 
 R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
 R --quiet -e "IRkernel::installspec(prefix='${PYTHON_VENV_PATH}')"

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -23,7 +23,7 @@ echo "export PATH=${PATH}" >> ${WORKDIR}/.profile
 su ${NB_USER}
 cd ${WORKDIR}
 python3 -m venv ${PYTHON_VENV_PATH}
-pip3 install --no-cache-dir jupyter-rsession-proxy>=2.0
+pip3 install --no-cache-dir jupyter-rsession-proxy>=2.0 notebook jupyterlab
 
 R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
 R --quiet -e "IRkernel::installspec(prefix='${PYTHON_VENV_PATH}')"


### PR DESCRIPTION
Previous versions did not work with latest R or RStudio,
which is the primary reason the binder image hasn't been working
recently

The other reason the repo wasn't working was because `jupyter notebook`
was the start command used, but jupyter-rsession-proxy no longer depended
on the `notebook` package. I've fixed that by installing notebook and jupyterlab.