### PR TITLE
omit locale warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 - In the newly built images, the default password for RStudio Server will be randomly generated when the server is started. ([#298](https://github.com/rocker-org/rocker-versioned2/pull/298))
 
+### Changes in rocker_scripts
+
+- The default locale, `LANG=en_US.UTF-8`, is now set [as recommended](https://github.com/docker-library/docs/tree/master/ubuntu#locales) by the official ubuntu image. ([#302](https://github.com/rocker-org/rocker-versioned2/issues/302), [#313](https://github.com/rocker-org/rocker-versioned2/pull/313))
+
 ## 2021-11
 
 ### Changes in rocker_scripts

--- a/build/make-dockerfiles.R
+++ b/build/make-dockerfiles.R
@@ -33,7 +33,7 @@ write_dockerfiles <- function(stack, global){
       paste_if("ENV", image),
       paste_if("COPY_a_script", image),
       paste_if("RUN_a_script", image),
-      paste_if("ENV_LANG", image),
+      paste_if("ENV_after_a_script", image),
       paste_if("COPY", image),
       paste_if("RUN", image),
       paste_if("EXPOSE", image),

--- a/build/make-dockerfiles.R
+++ b/build/make-dockerfiles.R
@@ -33,6 +33,7 @@ write_dockerfiles <- function(stack, global){
       paste_if("ENV", image),
       paste_if("COPY_a_script", image),
       paste_if("RUN_a_script", image),
+      paste_if("ENV_LANG", image),
       paste_if("COPY", image),
       paste_if("RUN", image),
       paste_if("EXPOSE", image),

--- a/dockerfiles/cuda11_4.1.0.Dockerfile
+++ b/dockerfiles/cuda11_4.1.0.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.0
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-09
 ENV TZ=Etc/UTC
@@ -22,6 +20,8 @@ ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/cuda11_4.1.1.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.1
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-10-29
 ENV TZ=Etc/UTC
@@ -22,6 +20,8 @@ ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/cuda11_4.1.2.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.2
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
 ENV TZ=Etc/UTC
@@ -22,6 +20,8 @@ ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/cuda11_devel.Dockerfile
+++ b/dockerfiles/cuda11_devel.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=devel
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/all/__linux__/focal/latest
 ENV TZ=Etc/UTC
@@ -22,6 +20,8 @@ ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}:${CUDA_HOME}/bin
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver-ubuntu18.04_4.0.0.Dockerfile
+++ b/dockerfiles/r-ver-ubuntu18.04_4.0.0.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/291
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.0.Dockerfile
+++ b/dockerfiles/r-ver_4.0.0.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/291
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.1.Dockerfile
+++ b/dockerfiles/r-ver_4.0.1.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.1
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/296
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.2.Dockerfile
+++ b/dockerfiles/r-ver_4.0.2.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.2
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-07
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.3.Dockerfile
+++ b/dockerfiles/r-ver_4.0.3.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.3
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-17
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.4.Dockerfile
+++ b/dockerfiles/r-ver_4.0.4.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.4
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-03-30
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.0.5.Dockerfile
+++ b/dockerfiles/r-ver_4.0.5.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.0.5
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-05-17
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.1.0.Dockerfile
+++ b/dockerfiles/r-ver_4.1.0.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.0
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-09
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.1.1.Dockerfile
+++ b/dockerfiles/r-ver_4.1.1.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.1
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-10-29
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_4.1.2.Dockerfile
+++ b/dockerfiles/r-ver_4.1.2.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=4.1.2
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/latest
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/dockerfiles/r-ver_devel.Dockerfile
+++ b/dockerfiles/r-ver_devel.Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV R_VERSION=devel
 ENV TERM=xterm
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
 ENV R_HOME=/usr/local/lib/R
 ENV CRAN=https://cloud.r-project.org
 ENV TZ=Etc/UTC
@@ -16,6 +14,8 @@ ENV TZ=Etc/UTC
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 
 RUN /rocker_scripts/install_R.sh
+
+ENV LANG=en_US.UTF-8
 
 COPY scripts /rocker_scripts
 

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -7,7 +7,7 @@ apt-get update && apt-get -y install locales lsb-release
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 LANG=${LANG:-en_US.UTF-8}
 
-UBUNTU_VERSION=${UBUNTU_VERSION:-`lsb_release -sc`}
+UBUNTU_VERSION=${UBUNTU_VERSION:-$(lsb_release -sc)}
 CRAN=${CRAN:-https://cran.r-project.org}
 
 ##  mechanism to force source installs if we're using RSPM

--- a/scripts/install_R.sh
+++ b/scripts/install_R.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -e
 
-apt-get update && apt-get -y install lsb-release
+apt-get update && apt-get -y install locales lsb-release
+
+## Configure default locale, see https://github.com/docker-library/docs/tree/master/ubuntu#locales
+localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+LANG=${LANG:-en_US.UTF-8}
 
 UBUNTU_VERSION=${UBUNTU_VERSION:-`lsb_release -sc`}
-LANG=${LANG:-en_US.UTF-8}
-LC_ALL=${LC_ALL:-en_US.UTF-8}
 CRAN=${CRAN:-https://cran.r-project.org}
 
 ##  mechanism to force source installs if we're using RSPM
@@ -18,7 +20,7 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Set up and install R
+## Set up and install R
 R_HOME=${R_HOME:-/usr/local/lib/R}
 
 READLINE_VERSION=8
@@ -50,15 +52,10 @@ apt-get update \
     libreadline${READLINE_VERSION} \
     libtiff* \
     liblzma* \
-    locales \
     make \
     unzip \
     zip \
     zlib1g
-
-echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-locale-gen en_US.utf8
-/usr/sbin/update-locale LANG=en_US.UTF-8
 
 BUILDDEPS="curl \
     default-jdk \

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -27,14 +27,15 @@
       "ENV": {
         "R_VERSION": "4.0.0",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/291",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",
@@ -254,14 +255,15 @@
       "ENV": {
         "R_VERSION": "4.0.0",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/bionic/291",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -13,14 +13,15 @@
       "ENV": {
         "R_VERSION": "4.0.1",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/296",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -13,14 +13,15 @@
       "ENV": {
         "R_VERSION": "4.0.2",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-07",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -13,14 +13,15 @@
       "ENV": {
         "R_VERSION": "4.0.3",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-17",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -13,14 +13,15 @@
       "ENV": {
         "R_VERSION": "4.0.4",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-03-30",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -13,14 +13,15 @@
       "ENV": {
         "R_VERSION": "4.0.5",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-05-17",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -27,14 +27,15 @@
       "ENV": {
         "R_VERSION": "4.1.0",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-09",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",
@@ -267,8 +268,6 @@
       "ENV": {
         "R_VERSION": "4.1.0",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-09",
         "TZ": "Etc/UTC",
@@ -281,6 +280,9 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -27,14 +27,15 @@
       "ENV": {
         "R_VERSION": "4.1.1",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-10-29",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",
@@ -267,8 +268,6 @@
       "ENV": {
         "R_VERSION": "4.1.1",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-10-29",
         "TZ": "Etc/UTC",
@@ -281,6 +280,9 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -27,14 +27,15 @@
       "ENV": {
         "R_VERSION": "4.1.2",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/latest",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]",
@@ -312,8 +313,6 @@
       "ENV": {
         "R_VERSION": "4.1.2",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/latest",
         "TZ": "Etc/UTC",
@@ -326,6 +325,9 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -33,7 +33,7 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
-      "ENV": "LANG=en_US.UTF-8",
+      "ENV_LANG": "LANG=en_US.UTF-8",
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]"
@@ -244,7 +244,7 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
-      "ENV": "LANG=en_US.UTF-8",
+      "ENV_LANG": "LANG=en_US.UTF-8",
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -27,14 +27,13 @@
       "ENV": {
         "R_VERSION": "devel",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://cloud.r-project.org",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV": "LANG=en_US.UTF-8",
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]"
@@ -233,8 +232,6 @@
       "ENV": {
         "R_VERSION": "devel",
         "TERM": "xterm",
-        "LC_ALL": "en_US.UTF-8",
-        "LANG": "en_US.UTF-8",
         "R_HOME": "/usr/local/lib/R",
         "CRAN": "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
         "TZ": "Etc/UTC",
@@ -247,6 +244,7 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
+      "ENV": "LANG=en_US.UTF-8",
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -33,7 +33,9 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
-      "ENV_LANG": "LANG=en_US.UTF-8",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": "/rocker_scripts/patch_install_command.sh",
       "CMD": "[\"R\"]"
@@ -244,7 +246,9 @@
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
       "RUN_a_script": "/rocker_scripts/install_R.sh",
-      "ENV_LANG": "LANG=en_US.UTF-8",
+      "ENV_after_a_script": {
+        "LANG": "en_US.UTF-8"
+      },
       "COPY": "scripts /rocker_scripts",
       "RUN": [
         "/rocker_scripts/patch_install_command.sh",


### PR DESCRIPTION
This PR should fix "cannot change locale" warnings, i.e. it fixes #302. 

1. The LANG environment variable is set only after the locales package is installed and localedef is run in both install_R.sh and the dockerfile(s) 
2. localedef is used instead of locale-gen (as [recommended](https://github.com/docker-library/docs/tree/master/ubuntu#locales) for the official ubuntu image).
3. `/etc/default/locale` is not set, since it doesn't seem to be necessary.
2. LC_ALL is not set (setting LC_ALL permanently is strongly discouraged, e.g. in the [Debian wiki](https://wiki.debian.org/Locale#Configuration))

I am not sure whether I fully understood the way the stacks and dockerfiles are created. Have I changed everything necessary for the dockerfiles for devel and current R versions?

Do you want me to add corresponding changes to the stack files for versions < 4.1.2?