### PR TITLE
Add a new step for the main build workflow to cancel previous build workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,6 +23,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
       - id: set-json
         run: |


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50911393/147238265-3bc2c8ea-ce58-4ba4-9c46-43b9c3c6b66d.png)

Yesterday, three builds were done in short intervals, from 979d7364f63fa8e7b7307c50bffbb32e8ced71cb, 096e6151f53f64fa6a8418f00e4c886474b9c05b and 54e338422c3c619fcda5a2fec19b90ea3c45b092.
As a result, the second build finished later than the third, so what we see tagged now are images from the second build that does not reflect the commit that triggered the third build 54e338422c3c619fcda5a2fec19b90ea3c45b092.

https://github.com/rocker-org/rocker-versioned2/wiki/r-ver_8a031e25eda6

![image](https://user-images.githubusercontent.com/50911393/147239102-afa7b7a0-951c-4491-bb75-fdb45747b826.png)

To avoid this kind of trouble, add a step to cancel the execution of previous workflow that is running at the time the workflow starts.

Since there is no tag such as `v1` in the aciton adopted this time (https://github.com/styfle/cancel-workflow-action), and it can only be specified as a patch version, I recommend merging #233 and using dependabot to automatically update the workflow definition.