### PR TITLE
Add `EXPOSE 8888` (jupyter default port) to `rocker/binder`'s Dockerfile and add `ExposePorts` to reports

### DIFF
--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -82,8 +82,12 @@ df_inspect <- jsonlite::read_json(params$inspect_file) |>
     CreatedTime = "Created",
     "Size",
     Env = list("Config", "Env"),
+    ExposedPorts = list("Config", "ExposedPorts"),
     Entrypoint = list("Config", "Entrypoint"),
-    Cmd = list("Config", "Cmd")
+    Cmd = list("Config", "Cmd"),
+    .transform = list(
+      ExposedPorts = names
+    )
   )
 
 df_inspect |>
@@ -94,6 +98,7 @@ df_inspect |>
     BaseImage = paste0("`", BaseImage, "`"),
     Size = paste0(format(round(Size / 10^6), big.mark = ","), "MB"),
     Env = stringr::str_c(unlist(Env), collapse = ", "),
+    ExposedPorts = stringr::str_c(unlist(ExposedPorts), collapse = ", "),
     Entrypoint = .list_to_jsonarray(Entrypoint),
     Cmd = .list_to_jsonarray(Cmd)
   ) |>

--- a/dockerfiles/binder_4.0.0.Dockerfile
+++ b/dockerfiles/binder_4.0.0.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.0.1.Dockerfile
+++ b/dockerfiles/binder_4.0.1.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.0.2.Dockerfile
+++ b/dockerfiles/binder_4.0.2.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.0.3.Dockerfile
+++ b/dockerfiles/binder_4.0.3.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.0.4.Dockerfile
+++ b/dockerfiles/binder_4.0.4.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.0.5.Dockerfile
+++ b/dockerfiles/binder_4.0.5.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.1.0.Dockerfile
+++ b/dockerfiles/binder_4.1.0.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.1.1.Dockerfile
+++ b/dockerfiles/binder_4.1.1.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_4.1.2.Dockerfile
+++ b/dockerfiles/binder_4.1.2.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/dockerfiles/binder_devel.Dockerfile
+++ b/dockerfiles/binder_devel.Dockerfile
@@ -10,6 +10,8 @@ ENV NB_USER=rstudio
 RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
+EXPOSE 8888
+
 CMD jupyter notebook --ip 0.0.0.0
 
 USER ${NB_USER}

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -160,6 +160,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.0"
       ]

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -146,6 +146,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.1"
       ]

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -146,6 +146,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.2"
       ]

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -146,6 +146,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.3"
       ]

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -146,6 +146,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.4"
       ]

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -153,6 +153,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.5",
         "docker.io/rocker/binder:4.0"

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -168,6 +168,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.0"
       ]

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -168,6 +168,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.1"
       ]

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -189,6 +189,7 @@
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
       "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.2",
         "docker.io/rocker/binder:4.1",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -136,7 +136,8 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0"
+      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "EXPOSE": 8888
     },
     {
       "IMAGE": "cuda",


### PR DESCRIPTION
Make it clear in Dockerfiles that `rocker/binder` uses port 8888.
EXPOSE will be listed as ExposedPort on the reports.

Note that inspecting `rocker/binder` will also show 8787 (added by `rocker/rstudio`), which is not actually used, since it is currently not possible to remove EXPOSE from an upstream image.

# Sample

## rocker/r-ver

![rocker/r-ver](https://user-images.githubusercontent.com/50911393/148678459-3449af20-4517-4990-a087-150c18f498c3.png)

## rocker/rstudio

![rocker/rstudio](https://user-images.githubusercontent.com/50911393/148678482-d370cc1a-68ce-455c-b386-367deeaa9875.png)

## rocker/binder

![rocker/binder](https://user-images.githubusercontent.com/50911393/148678532-c46012e8-3a5c-4a6f-8cc1-b8acefd2bb7a.png)
