### PR TITLE
Parallelization of the report generation job

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -73,7 +73,7 @@ jobs:
           path: tmp
       - name: Generate reports and update wiki home
         run: |
-          make --jobs report-all
+          make --jobs=2 report-all
           make wiki-home
       - name: Update wiki
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -73,7 +73,7 @@ jobs:
           path: tmp
       - name: Generate reports and update wiki home
         run: |
-          make report-all
+          make --jobs report-all
           make wiki-home
       - name: Update wiki
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/build/knit-report.R
+++ b/build/knit-report.R
@@ -35,6 +35,8 @@ apt_file <- arguments$apt_file
 r_file <- arguments$r_file
 pip_file <- arguments$pip_file
 
+intermediates_dir <- NULL
+
 if (arguments$directory == TRUE) {
   directory_name <- arguments$directory_name
   inspect_file <- paste0(directory_name, "/docker_inspect.json")
@@ -42,10 +44,12 @@ if (arguments$directory == TRUE) {
   apt_file <- paste0(directory_name, "/apt_packages.tsv")
   r_file <- paste0(directory_name, "/r_packages.ssv")
   pip_file <- paste0(directory_name, "/pip_packages.ssv")
+  intermediates_dir <- directory_name
 }
 
 rmarkdown::render(
   input = template,
+  intermediates_dir = intermediates_dir,
   output_dir = output_dir,
   output_file = paste0(arguments$image_name, ".md"),
   params = list(


### PR DESCRIPTION
Enables parallelization of the report generation job (`make report-all`) with the `-j` (`--jobs`) option of make.
On the GitHubActions workflow, it seems to be faster to limit the parallel execution to 2 than unlimited.

The execution time has been reduced to 3 minutes, compared to the 5 minutes it takes to generate all reports in the current unparallelized state.

![image](https://user-images.githubusercontent.com/50911393/148686161-7a83d9b3-bcb8-4951-9195-824287b3d613.png)

The reason I haven't been able to parallelize is the `intermediates_dir` option of the `rmarkdown::render()` function was not set, the report would fail to be created when parallelized because the intermediate files of each report were generated in the same path.

Thanks to @atusy for looking into a solution for parallel execution [on Twitter](https://twitter.com/Atsushi776/status/1479792149294379017).
