### PR TITLE
Adjust the date of the CRAN mirrors for freezed images (R4.0.0 to R4.0.3)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@
 ### Changes in pre-built images
 
 - Environment variables set in the container are now reflected in the sessions on Shiny Server. ([#320](https://github.com/rocker-org/rocker-versioned2/pull/320))
+- Change the date of the CRAN mirrors that were set for the R 4.0.0, R 4.0.1, R 4.0.2, and R 4.0.3 images. This reconfiguration was done mechanically, selecting the mirrors just before the release date of the next version of R. ([#328](https://github.com/rocker-org/rocker-versioned2/pull/328))
+  - R 4.0.0: 2020-06-08 to 2020-06-04 (The next version, R 4.0.1 was released on 2020-06-06)
+  - R 4.0.1: 2020-06-25 to 2020-06-18 (The next version, R 4.0.2 was released on 2020-06-22)
+  - R 4.0.2: 2020-10-07 to 2020-10-09 (The next version, R 4.0.3 was released on 2020-10-10)
+  - R 4.0.3: 2021-02-17 to 2021-02-11 (The next version, R 4.0.4 was released on 2021-02-15)
 
 ## 2021-12
 

--- a/dockerfiles/r-ver-ubuntu18.04_4.0.0.Dockerfile
+++ b/dockerfiles/r-ver-ubuntu18.04_4.0.0.Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/291
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/2020-06-04
 ENV TZ=Etc/UTC
 
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh

--- a/dockerfiles/r-ver_4.0.0.Dockerfile
+++ b/dockerfiles/r-ver_4.0.0.Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV R_VERSION=4.0.0
 ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/291
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2020-06-04
 ENV TZ=Etc/UTC
 
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh

--- a/dockerfiles/r-ver_4.0.1.Dockerfile
+++ b/dockerfiles/r-ver_4.0.1.Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV R_VERSION=4.0.1
 ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/296
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2020-06-18
 ENV TZ=Etc/UTC
 
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh

--- a/dockerfiles/r-ver_4.0.2.Dockerfile
+++ b/dockerfiles/r-ver_4.0.2.Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV R_VERSION=4.0.2
 ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-07
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-09
 ENV TZ=Etc/UTC
 
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh

--- a/dockerfiles/r-ver_4.0.3.Dockerfile
+++ b/dockerfiles/r-ver_4.0.3.Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV R_VERSION=4.0.3
 ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
-ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-17
+ENV CRAN=https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-11
 ENV TZ=Etc/UTC
 
 COPY scripts/install_R.sh /rocker_scripts/install_R.sh

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -28,7 +28,7 @@
         "R_VERSION": "4.0.0",
         "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
-        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/291",
+        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2020-06-04",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",
@@ -257,7 +257,7 @@
         "R_VERSION": "4.0.0",
         "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
-        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/bionic/291",
+        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/bionic/2020-06-04",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -14,7 +14,7 @@
         "R_VERSION": "4.0.1",
         "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
-        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/296",
+        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2020-06-18",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -14,7 +14,7 @@
         "R_VERSION": "4.0.2",
         "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
-        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-07",
+        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2020-10-09",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -14,7 +14,7 @@
         "R_VERSION": "4.0.3",
         "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
-        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-17",
+        "CRAN": "https://packagemanager.rstudio.com/cran/__linux__/focal/2021-02-11",
         "TZ": "Etc/UTC"
       },
       "COPY_a_script": "scripts/install_R.sh /rocker_scripts/install_R.sh",


### PR DESCRIPTION
close #325

Change the dates of the CRAN mirrors for the old images as follows.

- R 4.0.0: 2020-06-08 to 2020-06-04 (The next version, R 4.0.1 was released on 2020-06-06)
- R 4.0.1: 2020-06-25 to 2020-06-18 (The next version, R 4.0.2 was released on 2020-06-22)
- R 4.0.2: 2020-10-07 to 2020-10-09 (The next version, R 4.0.3 was released on 2020-10-10)
- R 4.0.3: 2021-02-17 to 2021-02-11 (The next version, R 4.0.4 was released on 2021-02-15)

The URLs of the valid CRAN mirrors can be found in the GitHubActions log, which runs daily.
https://github.com/rocker-org/rocker-versioned2/actions/workflows/dockerfiles.yml

![image](https://user-images.githubusercontent.com/50911393/148932823-9b8f18bc-5a00-481f-962e-ac510435bd06.png)
