### PR TITLE
Add xgboost stan install and test scripts

### DIFF
--- a/scripts/install_stan.R
+++ b/scripts/install_stan.R
@@ -1,0 +1,6 @@
+# install stan
+# users should run this script to install stan their R session
+
+install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+library(cmdstanr)
+install_cmdstan()

--- a/scripts/install_xgboost.sh
+++ b/scripts/install_xgboost.sh
@@ -1,0 +1,38 @@
+# Xgboost
+
+set -e
+set -x
+
+apt update && apt install -y software-properties-common
+
+# apt-get update
+# apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --allow-unauthenticated --no-install-recommends --no-upgrade \
+#   gcc-8 \
+#   g++-8 \
+#   libnccl2 \
+#   libnccl-dev
+
+# install nvidia toolkit
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+apt update && apt install -y nvidia-cuda-dev nvidia-cuda-toolkit
+
+# install cmake
+apt update && apt install -y build-essential libssl-dev gcc-8 g++-8
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+mkdir /tmp/cmake
+cd /tmp/cmake
+wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0.tar.gz
+tar -zxvf cmake-3.20.0.tar.gz
+cd /tmp/cmake/cmake-3.20.0
+./bootstrap
+make
+make install
+
+# compile xgboost
+cd /root
+git clone --recursive https://github.com/dmlc/xgboost
+mkdir /root/xgboost/build
+cd /root/xgboost/build
+cmake .. -DUSE_CUDA=ON -DR_LIB=ON -DUSE_NCCL=ON -DNCCL_ROOT=/usr/lib/x86_64-linux-gnu
+make install -j4

--- a/scripts/tests/stan.R
+++ b/scripts/tests/stan.R
@@ -1,0 +1,12 @@
+library(cmdstanr)
+# Generate some fake data
+n <- 250000
+k <- 20
+X <- matrix(rnorm(n * k), ncol = k)
+y <- rbinom(n, size = 1, prob = plogis(3 * X[,1] - 2 * X[,2] + 1))
+mdata <- list(k = k, n = n, y = y, X = X)
+download.file("https://raw.githubusercontent.com/stan-dev/cmdstanr/master/vignettes/articles-online-only/opencl-files/bernoulli_logit_glm.stan", destfile = "test.stan")
+mod_cl <- cmdstan_model("test.stan",
+                        cpp_options = list(stan_opencl = TRUE))
+fit_cl <- mod_cl$sample(data = mdata, chains = 4, parallel_chains = 4,
+                        opencl_ids = c(0, 0), refresh = 0)

--- a/scripts/tests/xgboost.R
+++ b/scripts/tests/xgboost.R
@@ -1,0 +1,45 @@
+# An example of using GPU-accelerated tree building algorithms
+#
+# NOTE: it can only run if you have a CUDA-enable GPU and the package was
+#       specially compiled with GPU support.
+#
+# For the current functionality, see
+# https://xgboost.readthedocs.io/en/latest/gpu/index.html
+#
+
+library('xgboost')
+
+# Simulate N x p random matrix with some binomial response dependent on pp columns
+set.seed(111)
+N <- 1000000
+p <- 50
+pp <- 25
+X <- matrix(runif(N * p), ncol = p)
+betas <- 2 * runif(pp) - 1
+sel <- sort(sample(p, pp))
+m <- X[, sel] %*% betas - 1 + rnorm(N)
+y <- rbinom(N, 1, plogis(m))
+
+tr <- sample.int(N, N * 0.75)
+dtrain <- xgb.DMatrix(X[tr, ], label = y[tr])
+dtest <- xgb.DMatrix(X[-tr, ], label = y[-tr])
+wl <- list(train = dtrain, test = dtest)
+
+# An example of running 'gpu_hist' algorithm
+# which is
+# - similar to the 'hist'
+# - the fastest option for moderately large datasets
+# - current limitations: max_depth < 16, does not implement guided loss
+# You can use tree_method = 'gpu_hist' for another GPU accelerated algorithm,
+# which is slower, more memory-hungry, but does not use binning.
+param <- list(objective = 'reg:logistic', eval_metric = 'auc', subsample = 0.5, nthread = 4,
+              max_bin = 64, tree_method = 'gpu_hist')
+pt <- proc.time()
+bst_gpu <- xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
+proc.time() - pt
+
+# Compare to the 'hist' algorithm:
+param$tree_method <- 'hist'
+pt <- proc.time()
+bst_hist <- xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
+proc.time() - pt


### PR DESCRIPTION
Here's code to install and test gpu supported xgboost and stan.  Please let me know if I should move or add anything.

I'm not sure if I've put `install_stan.R` in the right place since it needs to be run by users to install stan.  Is there a better place for it.

I got the xgboost test script from `https://rdrr.io/cran/xgboost/src/demo/gpu_accelerated.R`.  Please let me know if you think there's something better we could use.

