### PR TITLE
Add `Versions.md` to the wiki

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Generate reports and update wiki home
         run: |
           make --jobs=2 report-all
-          make wiki-home
+          make --always-make wiki-home
       - name: Update wiki
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ REPORT_SOURCE_ROOT ?= tmp/inspects
 IMAGELIST_DIR ?= tmp/imagelist
 IMAGELIST_NAME ?= imagelist.tsv
 REPORT_DIR ?= reports
+STACK_FILES ?= $(wildcard stacks/*.json)
 IMAGE_FILTER ?= label=org.opencontainers.image.source=$(IMAGE_SOURCE)
 inspect-image/%:
 	mkdir -p $(REPORT_SOURCE_ROOT)/$*
@@ -73,9 +74,13 @@ report-all: $(foreach I, $(wildcard $(REPORT_SOURCE_ROOT)/*), report/$(I))
 
 
 # Move image list to wiki and update Home.md
-wiki-home:
+wiki-home: $(REPORT_DIR)/Versions.md $(REPORT_DIR)/_Sidebar.md
 	cp -r $(IMAGELIST_DIR) $(REPORT_DIR)
 	-Rscript -e 'rmarkdown::render(input = "build/reports/wiki_home.Rmd", output_dir = "$(REPORT_DIR)", output_file = "Home.md")'
+$(REPORT_DIR)/_Sidebar.md: build/reports/_Sidebar.md
+	cp $< $@
+$(REPORT_DIR)/Versions.md: build/reports/versions.Rmd $(STACK_FILES)
+	-Rscript -e 'rmarkdown::render(input = "$<", output_dir = "$(@D)", output_file = "$(@F)")'
 
 clean:
 	rm -r -f dockerfiles/*.Dockerfile bakefiles/*.json tmp/*

--- a/build/README.md
+++ b/build/README.md
@@ -20,3 +20,15 @@ Since 2021-08-10, the information of images built from this repository will be r
 Running `make inspect-image-all` (requires `docker`), then `make report-all` (requires R >= 4.1.0 and some packages) will generate reports about rocker images, in `reports/` directory (ignored by git). The template for the reports is `build/reports/template.Rmd` and the script for giving variables to the template is `./build/knit-report.R`.
 
 The wiki HOME(`Home.md`) is generated from `build/reports/wiki_home.Rmd`.
+
+## How to control which Docker images to build
+
+### Stop building a specific R version
+
+Variables described in the stack files that exist in each version may be referenced during document generation.
+
+So, if you no longer need to build a particular R version, please edit the `make-matrix.R` script and exclude that R version from the build matrix, instead of remove the stack file for that version.
+
+### Stop building a specific image of a specific R version
+
+Images that are not included in the `groups` defined in `docker-bake.json` files will not be built, so if you want to select images to build in each version of the stack file, edit the `make-stacks.R` script and adjust the contents of `groups`.

--- a/build/README.md
+++ b/build/README.md
@@ -31,4 +31,4 @@ So, if you no longer need to build a particular R version, please edit the `make
 
 ### Stop building a specific image of a specific R version
 
-Images that are not included in the `groups` defined in `docker-bake.json` files will not be built, so if you want to select images to build in each version of the stack file, edit the `make-stacks.R` script and adjust the contents of `groups`.
+Images that are not included in the `groups` defined in `docker-bake.json` files will not be built, so if you want to select images to build in each version of the stack file, edit the stack files and the `make-stacks.R` script to adjust the contents of `groups`.

--- a/build/reports/_Sidebar.md
+++ b/build/reports/_Sidebar.md
@@ -1,0 +1,5 @@
+## [[Home]]
+
+## Docs
+
+- [[Versions]]: Description of some variables determined by the version of R.

--- a/build/reports/_Sidebar.md
+++ b/build/reports/_Sidebar.md
@@ -1,5 +1,7 @@
 ## [[Home]]
 
+A list of the latest images and links to each reports can be found at Home.
+
 ## Docs
 
 - [[Versions]]: Description of some variables determined by the version of R.

--- a/build/reports/versions.Rmd
+++ b/build/reports/versions.Rmd
@@ -86,7 +86,7 @@ df_stacks |>
   dplyr::arrange(numeric_version(r_version)) |>
   dplyr::select(
     `R version` = r_version,
-    `Release date` = release_date,
+    `R release date` = release_date,
     `CRAN date` = cran_date,
     `RStudio version` = rstudio_version,
     `Ubuntu version` = version

--- a/build/reports/versions.Rmd
+++ b/build/reports/versions.Rmd
@@ -27,17 +27,19 @@ library(fs)
 library(rversions)
 ```
 
-In order to get coherent versioned Rocker containers, versions of R, R packages, and RStudio Server are match on a time scale by default.
+In order to get coherent versioned Rocker containers, versions of R, R packages, RStudio Server, and TeX packages are match on a time scale by default.
 
 For information about old images with 3.X.X tags, please check [the `rocker-org/rocker-versioned` repository](https://github.com/rocker-org/rocker-versioned/blob/master/VERSIONS.md).
 
 ## Rules
 
+- Ubuntu version is the latest Ubuntu LTS version when that R version was released.
 - CRAN date is the date of the last CRAN snapshot in the era when that R version was the latest.
-  - If that R version is the latest, the CRAN date will not be set and the latest package will always be installed.
+  - If that R version is the latest, the CRAN date will not be set and the latest packages will always be installed.
 - RStudio version is the latest stable RStudio version of the era when that R version was the latest.
   - If a new RStudio is released when that R version is the latest, the configuration will be updated to install the new RStudio.
-- Ubuntu version is the latest Ubuntu LTS version when that R version was released.
+- CTAN date is the day before the next R version release date.
+  - If that R version is the latest, the CTAN date will not be set and the latest packages will always be installed.
 
 ## Versions
 
@@ -87,9 +89,9 @@ df_stacks |>
   dplyr::select(
     `R version` = r_version,
     `R release date` = release_date,
+    `Ubuntu version` = version,
     `CRAN date` = cran_date,
-    `RStudio version` = rstudio_version,
-    `Ubuntu version` = version
+    `RStudio version` = rstudio_version
   ) |>
   knitr::kable()
 ```

--- a/build/reports/versions.Rmd
+++ b/build/reports/versions.Rmd
@@ -1,0 +1,98 @@
+---
+title: R, CRAN, RStudio Server versions correspondance
+output:
+  github_document:
+    toc: false
+    df_print: kable
+    html_preview: false
+---
+
+```{comment}
+The R code contained in this file only work on Ubuntu.
+```
+
+```{r setup, include=FALSE}
+options(knitr.kable.NA = "")
+
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
+knitr::opts_knit$set(root.dir = rprojroot::find_root_file(criterion = rprojroot::is_git_root))
+
+library(dplyr)
+library(tibble)
+library(stringr)
+library(purrr)
+library(lubridate)
+library(jsonlite)
+library(fs)
+library(rversions)
+```
+
+In order to get coherent versioned Rocker containers, versions of R, R packages, and RStudio Server are match on a time scale by default.
+
+For information about old images with 3.X.X tags, please check [the `rocker-org/rocker-versioned` repository](https://github.com/rocker-org/rocker-versioned/blob/master/VERSIONS.md).
+
+## Rules
+
+- CRAN date is the date of the last CRAN snapshot in the era when that R version was the latest.
+  - If that R version is the latest, the CRAN date will not be set and the latest package will always be installed.
+- RStudio version is the latest stable RStudio version of the era when that R version was the latest.
+  - If a new RStudio is released when that R version is the latest, the configuration will be updated to install the new RStudio.
+- Ubuntu version is the latest Ubuntu LTS version when that R version was released.
+
+## Versions
+
+```{r}
+.read_stacks <- function(path) {
+  jsonlite::read_json(path)$stack |>
+    tibble::enframe(name = NULL) |>
+    tidyr::hoist(
+      value,
+      image = "IMAGE",
+      r_version = c("ENV", "R_VERSION"),
+      cran_date = c("ENV", "CRAN"),
+      ubuntu_series = "FROM",
+      rstudio_version = c("ENV", "RSTUDIO_VERSION"),
+      .transform = list(
+        cran_date = ~ stringr::str_extract(.x, pattern = "\\d{4}-\\d{2}-\\d{2}$") |>
+          lubridate::as_date(),
+        ubuntu_series = ~ stringr::str_remove(.x, pattern = "^ubuntu:")
+      )
+    ) |>
+    tidyr::fill(rstudio_version, .direction = "up") |>
+    dplyr::filter(image == "r-ver") |>
+    dplyr::select(
+      r_version,
+      cran_date,
+      rstudio_version,
+      ubuntu_series
+    )
+}
+
+
+df_stacks <- fs::dir_ls(path = "stacks", regexp = "([0-9]+\\.){3}json$") |>
+  purrr::map_dfr(.read_stacks)
+
+df_rversions <- rversions::r_versions() |>
+  dplyr::transmute(
+    r_version = version,
+    release_date = lubridate::as_date(date)
+  )
+
+df_ubuntu <- readr::read_csv("/usr/share/distro-info/ubuntu.csv", col_select = c("version", "series"))
+
+df_stacks |>
+  dplyr::left_join(df_rversions, by = "r_version") |>
+  dplyr::left_join(df_ubuntu, by = c("ubuntu_series" = "series")) |>
+  dplyr::arrange(numeric_version(r_version)) |>
+  dplyr::select(
+    `R version` = r_version,
+    `Release date` = release_date,
+    `CRAN date` = cran_date,
+    `RStudio version` = rstudio_version,
+    `Ubuntu version` = version
+  ) |>
+  knitr::kable()
+```
+
+Note: This table was generated from the latest definition files in the source repository, so the container images that were built and pushed may have different values set.
+Please check the individual reports on this wiki for the actual contents of the images.

--- a/build/reports/versions.Rmd
+++ b/build/reports/versions.Rmd
@@ -94,5 +94,5 @@ df_stacks |>
   knitr::kable()
 ```
 
-Note: This table was generated from the latest definition files in the source repository, so the container images that were built and pushed may have different values set.
-Please check the individual reports on this wiki for the actual contents of the images.
+_Note: This table was generated from the latest definition files in the source repository, so the container images that were built and pushed may have different values set.
+Please check the individual reports on this wiki for the actual contents of the images._


### PR DESCRIPTION
Related to #201

Now that #328 has been merged, we can generate a table to see the list of configuration values for each version, like https://github.com/rocker-org/rocker-versioned/blob/master/VERSIONS.md
I think it would be useful if this could be registered in the wiki and automatically updated.

## Screen shot

### Versions.md

![image](https://user-images.githubusercontent.com/50911393/149558272-acff3016-e23b-460d-808d-64a131b082a2.png)

### sidebar

![image](https://user-images.githubusercontent.com/50911393/153444890-a2c3cf86-a802-4ad1-8efa-e2300884e7da.png)

**ToDo**

- [x] Add sidebar of the wiki
- [x] Update the job to update wiki
- [x] Update `build/README.md` (About the disappearance of the corresponding version from `Versions.md` when the stackfile is deleted)

