### PR TITLE
Add `distill` as package

### DIFF
--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -75,7 +75,13 @@ wget "https://travis-bin.yihui.name/texlive-local.deb" \
 
 install2.r --error --skipinstalled -n $NCPUS tinytex
 install2.r --error --deps TRUE --skipinstalled -n $NCPUS \
-    blogdown bookdown rticles rmdshower rJava xaringan
+    blogdown \
+    bookdown \
+    distill \
+    rticles \
+    rmdshower \
+    rJava \
+    xaringan
 
 rm -rf /tmp/downloaded_packages
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I think [`distill`](https://rstudio.github.io/distill/) would be a great candidate to be integrated in rocker/verse as it says to provide "(...) publishing-related packages".