### PR TITLE
Minor updates in some scripts

### DIFF
--- a/scripts/bin/install2.r
+++ b/scripts/bin/install2.r
@@ -51,16 +51,14 @@ if (opt$deps == "TRUE" || opt$deps == "FALSE") {
     opt$deps <- NA
 }
 
-if (length(opt$repos) == 1) {
-    ## docopt results are characters, so if we meant NULL we have to set NULL
-    if (opt$repos == "NULL")  {
-        opt$repos <- NULL
-    } else {
-        if (opt$repos == "getOption") {
-            ## as littler can now read ~/.littler.r and/or /etc/littler.r we can preset elsewhere
-            opt$repos <- getOption("repos")
-        }
-    }
+## docopt results are characters, so if we meant NULL we have to set NULL
+if (length(opt$repos) == 1 && "NULL" %in% opt$repos) {
+    opt$repos <- NULL
+}
+
+if ("getOption" %in% opt$repos) {
+    ## as littler can now read ~/.littler.r and/or /etc/littler.r we can preset elsewhere
+    opt$repos <- c(opt$repos[which(opt$repos != "getOption")], getOption("repos"))
 }
 
 if (opt$ncpus == "getOption") {
@@ -144,7 +142,7 @@ if (any(isLocal)) {
     install_packages2(pkgs = opt$PACKAGES,
                       lib = opt$libloc,
                       repos = opt$repos,
-                      dependencies = opt$dep,
+                      dependencies = opt$deps,
                       INSTALL_opts = installOpts,
                       Ncpus = opt$ncpus,
                       method = opt$method,

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -38,12 +38,6 @@ rm -rf /var/lib/apt/lists/*
 # install s6 supervisor
 /rocker_scripts/install_s6init.sh
 
-## Download and install RStudio server & dependencies
-## Uses, in order of preference, first argument of the script, the
-## RSTUDIO_VERSION variable, or the latest RStudio version.  "latest", "preview",
-## or "daily" may be used.
-##
-## Also symlinks pandoc, pandoc-citeproc so they are available system-wide,
 export PATH=/usr/lib/rstudio-server/bin:$PATH
 
 

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -3,7 +3,7 @@ set -e
 
 ### Sets up S6 supervisor.
 
-S6_VERSION=${1:-${S6_VERSION:-v1.21.7.0}}
+S6_VERSION=${1:-${S6_VERSION:-"v2.1.0.2"}}
 S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 ARCH=$(dpkg --print-architecture)


### PR DESCRIPTION
Reflect corrections I missed in the past PR and upstream updates to the install2.r script.

1. I moved the comment position in `install_rstudio.sh` to the beginning of the script, but forgot to delete the comment in its original position. (#329)
2. I forgot to update the default S6 version to v2.1.0.2 hard-coded in the script. (#247)
3. Upstream update of `install2.r`.