### PR TITLE
Support for quarto and pandoc bundled with RStudio

### DIFF
--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -40,7 +40,9 @@ if [ "$PANDOC_VERSION" != "$INSTALLED_PANDOC_VERSION" ]; then
 
   if [ "$PANDOC_VERSION" = "$BUNDLED_PANDOC_VERSION" ] || [ "$PANDOC_VERSION" = "default" ]; then
     ln -fs "$BUNDLED_PANDOC" /usr/local/bin
-    ln -fs "${BUNDLED_PANDOC}-citeproc" /usr/local/bin
+    if [ -f "${BUNDLED_PANDOC}-citeproc" ]; then
+      ln -fs "${BUNDLED_PANDOC}-citeproc" /usr/local/bin
+    fi
   else
     if [ -L "/usr/local/bin/pandoc" ]; then
       unlink /usr/local/bin/pandoc

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
+
+## Install pandoc or symlinks pandoc, pandoc-citeproc so they are available system-wide.
+##
+## In order of preference, first argument of the script, the PANDOC_VERSION variable.
+## ex. latest, default
+##
+## Note that 'default' pandoc version means the version bundled with RStudio If RStudio is installed,
+## but 'latest' otherwise
+
 set -e
 
-# Note that 'default' pandoc version means the version bundled with RStudio
-# if RStudio is installed , but latest otherwise
-
-PANDOC_VERSION=${1:-${PANDOC_VERSION:-default}}
+PANDOC_VERSION=${1:-${PANDOC_VERSION:-"default"}}
 ARCH=$(dpkg --print-architecture)
 
 if [ ! -x "$(command -v wget)" ]; then
@@ -19,8 +25,8 @@ fi
 if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
 
   if [ -f "/usr/lib/rstudio-server/bin/pandoc/pandoc" ] &&
-      { [ "$PANDOC_VERSION" = "$(/usr/lib/rstudio-server/bin/pandoc/pandoc --version | head -n 1 | grep -oP '[\d\.]+$')" ] ||
-        [ "$PANDOC_VERSION" = "default" ]; }; then
+    { [ "$PANDOC_VERSION" = "$(/usr/lib/rstudio-server/bin/pandoc/pandoc --version | head -n 1 | grep -oP '[\d\.]+$')" ] ||
+      [ "$PANDOC_VERSION" = "default" ]; }; then
     ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin
     ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin
   else
@@ -35,7 +41,7 @@ if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
   fi
 
   ## Symlink pandoc & standard pandoc templates for use system-wide
-  PANDOC_TEMPLATES_VERSION=`pandoc -v | grep -oP "(?<=pandoc\s)[0-9\.]+$"`
+  PANDOC_TEMPLATES_VERSION=$(pandoc -v | grep -oP "(?<=pandoc\s)[0-9\.]+$")
   wget https://github.com/jgm/pandoc-templates/archive/${PANDOC_TEMPLATES_VERSION}.tar.gz -O pandoc-templates.tar.gz
   rm -fr /opt/pandoc/templates
   mkdir -p /opt/pandoc/templates

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -5,8 +5,8 @@
 ## In order of preference, first argument of the script, the PANDOC_VERSION variable.
 ## ex. latest, default
 ##
-## Note that 'default' pandoc version means the version bundled with RStudio If RStudio is installed,
-## but 'latest' otherwise
+## 'default' means the version bundled with RStudio if RStudio is installed, but 'latest' otherwise.
+## 'latest' means installing the latest release version.
 
 set -e
 
@@ -19,30 +19,49 @@ if [ ! -x "$(command -v wget)" ]; then
 fi
 
 if [ -x "$(command -v pandoc)" ]; then
-  INSTALLED_PANDOC=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
+  INSTALLED_PANDOC_VERSION=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
 fi
 
-if [ "$INSTALLED_PANDOC" != "$PANDOC_VERSION" ]; then
+if [ -f "/usr/lib/rstudio-server/bin/pandoc/pandoc" ]; then
+  BUNDLED_PANDOC="/usr/lib/rstudio-server/bin/pandoc/pandoc"
+elif [ -f "/usr/lib/rstudio-server/bin/quarto/bin/pandoc" ]; then
+  BUNDLED_PANDOC="/usr/lib/rstudio-server/bin/quarto/bin/pandoc"
+fi
 
-  if [ -f "/usr/lib/rstudio-server/bin/pandoc/pandoc" ] &&
-    { [ "$PANDOC_VERSION" = "$(/usr/lib/rstudio-server/bin/pandoc/pandoc --version | head -n 1 | grep -oP '[\d\.]+$')" ] ||
-      [ "$PANDOC_VERSION" = "default" ]; }; then
-    ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc /usr/local/bin
-    ln -fs /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc /usr/local/bin
+if [ -n "$BUNDLED_PANDOC" ]; then
+  BUNDLED_PANDOC_VERSION="$($BUNDLED_PANDOC --version | head -n 1 | grep -oP '[\d\.]+$')"
+fi
+
+if [ "$PANDOC_VERSION" != "$INSTALLED_PANDOC_VERSION" ]; then
+
+  if [ "$PANDOC_VERSION" = "default" ] && [ -z "$BUNDLED_PANDOC" ]; then
+    PANDOC_VERSION="latest"
+  fi
+
+  if [ "$PANDOC_VERSION" = "$BUNDLED_PANDOC_VERSION" ] || [ "$PANDOC_VERSION" = "default" ]; then
+    ln -fs "$BUNDLED_PANDOC" /usr/local/bin
+    ln -fs "${BUNDLED_PANDOC}-citeproc" /usr/local/bin
   else
-    if [ "$PANDOC_VERSION" = "default" ]; then
+    if [ -L "/usr/local/bin/pandoc" ]; then
+      unlink /usr/local/bin/pandoc
+    fi
+    if [ -L "/usr/local/bin/pandoc-citeproc" ]; then
+      unlink /usr/local/bin/pandoc-citeproc
+    fi
+
+    if [ "$PANDOC_VERSION" = "latest" ]; then
       PANDOC_DL_URL=$(wget -qO- https://api.github.com/repos/jgm/pandoc/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*${ARCH}\.deb")
     else
-      PANDOC_DL_URL=https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-${ARCH}.deb
+      PANDOC_DL_URL="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-${ARCH}.deb"
     fi
-    wget ${PANDOC_DL_URL} -O pandoc-${ARCH}.deb
-    dpkg -i pandoc-${ARCH}.deb
-    rm pandoc-${ARCH}.deb
+    wget "$PANDOC_DL_URL" -O pandoc.deb
+    dpkg -i pandoc.deb
+    rm pandoc.deb
   fi
 
   ## Symlink pandoc & standard pandoc templates for use system-wide
   PANDOC_TEMPLATES_VERSION=$(pandoc -v | grep -oP "(?<=pandoc\s)[0-9\.]+$")
-  wget https://github.com/jgm/pandoc-templates/archive/${PANDOC_TEMPLATES_VERSION}.tar.gz -O pandoc-templates.tar.gz
+  wget "https://github.com/jgm/pandoc-templates/archive/${PANDOC_TEMPLATES_VERSION}.tar.gz" -O pandoc-templates.tar.gz
   rm -fr /opt/pandoc/templates
   mkdir -p /opt/pandoc/templates
   tar xvf pandoc-templates.tar.gz

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
+
+## Install quarto cli or symlink quarto cli so they are available system-wide.
+##
+## In order of preference, first argument of the script, the QUARTO_VERSION variable.
+## ex. latest, default, 0.9.16
+##
+## 'default' means the version bundled with RStudio if RStudio is installed, but 'latest' otherwise.
+## 'latest' means installing the latest release version.
+
 set -e
 
 ## build ARGs
 NCPUS=${NCPUS:--1}
 
-QUARTO_VERSION=${1:-${QUARTO_VERSION:-latest}}
+QUARTO_VERSION=${1:-${QUARTO_VERSION:-"latest"}}
 # Only amd64 build can be installed now
 ARCH=$(dpkg --print-architecture)
 
@@ -14,25 +23,45 @@ if [ ! -x "$(command -v wget)" ]; then
 fi
 
 if [ -x "$(command -v quarto)" ]; then
-  INSTALLED_QUARTO=$(quarto --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
+  INSTALLED_QUARTO_VERSION=$(quarto --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
 fi
 
-if [ "$INSTALLED_QUARTO" != "$QUARTO_VERSION" ]; then
+# Check RStudio bundled quarto cli
+if [ -f "/usr/lib/rstudio-server/bin/quarto/bin/quarto" ]; then
+  BUNDLED_QUARTO="/usr/lib/rstudio-server/bin/quarto/bin/quarto"
+fi
 
-  if [ "$QUARTO_VERSION" = "latest" ]; then
-    QUARTO_DL_URL=$(wget -qO- https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*${ARCH}\.deb")
-  else
-    QUARTO_DL_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-${ARCH}.deb
+if [ -n "$BUNDLED_QUARTO" ]; then
+  BUNDLED_QUARTO_VERSION="$($BUNDLED_QUARTO --version)"
+fi
+
+# Install quarto cli
+if [ "$QUARTO_VERSION" != "$INSTALLED_QUARTO_VERSION" ]; then
+
+  # Check RStudio bundled quarto cli
+  if [ "$QUARTO_VERSION" = "default" ] && [ -z "$BUNDLED_QUARTO" ]; then
+    QUARTO_VERSION="latest"
   fi
-  wget "${QUARTO_DL_URL}" -O quarto-"${ARCH}".deb
-  dpkg -i quarto-"${ARCH}".deb
-  rm quarto-"${ARCH}".deb
+
+  if [ "$QUARTO_VERSION" = "$BUNDLED_QUARTO_VERSION" ] || [ "$QUARTO_VERSION" = "default" ]; then
+    ln -fs "$BUNDLED_QUARTO" /usr/local/bin
+  else
+    if [ "$QUARTO_VERSION" = "latest" ]; then
+      QUARTO_DL_URL=$(wget -qO- https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*${ARCH}\.deb")
+    else
+      QUARTO_DL_URL="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-${ARCH}.deb"
+    fi
+    wget "$QUARTO_DL_URL" -O quarto.deb
+    dpkg -i quarto.deb
+    rm quarto.deb
+  fi
 
   quarto check install
 
 fi
 
-install2.r --error --skipinstalled -n "$NCPUS" \
+# Install the quarto R package
+install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
   quarto
 
 # Clean up

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -23,7 +23,7 @@ if [ ! -x "$(command -v wget)" ]; then
 fi
 
 if [ -x "$(command -v quarto)" ]; then
-  INSTALLED_QUARTO_VERSION=$(quarto --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')
+  INSTALLED_QUARTO_VERSION=$(quarto --version)
 fi
 
 # Check RStudio bundled quarto cli

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 ## Download and install RStudio server & dependencies uses.
-## Also symlinks pandoc, pandoc-citeproc so they are available system-wide.
 ##
 ## In order of preference, first argument of the script, the RSTUDIO_VERSION variable.
 ## ex. stable, preview, daily, 1.3.959, 2021.09.1+372, 2021.09.1-372, 2022.06.0-daily+11


### PR DESCRIPTION
Fix #367

The latest release version of RStudio (2022.02.0+443) now bundles quarto instead of pandoc, which was previously bundled.
Therefore, the pandoc path bundled with RStudio is different from the path hard-coded in `install_pandoc.sh`.

This PR fixes this issue and makes it compatible with the new bundled version of pandoc path.
And adds an option to `install_quarto.sh` to use the RStudio bundled version of quarto.

I also noticed that the `pandoc-citeproc` executable files that once existed are no longer present.

```shell
$ docker run --rm -it rocker/rstudio:4.1.1 bash
root@30c15e2ae440:/# ls -l /usr/local/bin/pandoc*
lrwxrwxrwx 1 root root 41 Nov  1 18:41 /usr/local/bin/pandoc -> /usr/lib/rstudio-server/bin/pandoc/pandoc
lrwxrwxrwx 1 root root 50 Nov  1 18:41 /usr/local/bin/pandoc-citeproc -> /usr/lib/rstudio-server/bin/pandoc/pandoc-citeproc
root@30c15e2ae440:/# ls /usr/lib/rstudio-server/bin/pandoc/pandoc*
/usr/lib/rstudio-server/bin/pandoc/pandoc
```

I changed so that symbolic links will not be created if this executable does not exist.