### PR TITLE
Add missing `PANDOC_VERSION` environment variable to rocker/rstudio and rocker/ml

### DIFF
--- a/dockerfiles/ml-cuda11_4.1.0.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.1.0.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1717
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/ml-cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.1.1.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/ml-cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.1.2.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2022.02.0+443
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/ml-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-cuda11_devel.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2022.02.0+443
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio-ubuntu18.04_4.0.0.Dockerfile
+++ b/dockerfiles/rstudio-ubuntu18.04_4.0.0.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.0.Dockerfile
+++ b/dockerfiles/rstudio_4.0.0.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.1.Dockerfile
+++ b/dockerfiles/rstudio_4.0.1.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.959
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.2.Dockerfile
+++ b/dockerfiles/rstudio_4.0.2.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.3.1093
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.3.Dockerfile
+++ b/dockerfiles/rstudio_4.0.3.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1106
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.4.Dockerfile
+++ b/dockerfiles/rstudio_4.0.4.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1106
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.0.5.Dockerfile
+++ b/dockerfiles/rstudio_4.0.5.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1106
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.1.0.Dockerfile
+++ b/dockerfiles/rstudio_4.1.0.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=1.4.1717
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.1.1.Dockerfile
+++ b/dockerfiles/rstudio_4.1.1.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2021.09.0+351
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_4.1.2.Dockerfile
+++ b/dockerfiles/rstudio_4.1.2.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2022.02.0+443
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_devel.Dockerfile
+++ b/dockerfiles/rstudio_devel.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=2022.02.0+443
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_latest-daily.Dockerfile
+++ b/dockerfiles/rstudio_latest-daily.Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=daily
 ENV DEFAULT_USER=rstudio
+ENV PANDOC_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -60,6 +60,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
@@ -289,6 +290,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -46,6 +46,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.959",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -46,6 +46,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.3.1093",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -46,6 +46,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.4.1106",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -46,6 +46,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.4.1106",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -47,6 +47,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.4.1106",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -64,6 +64,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.4.1717",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
@@ -311,6 +312,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "1.4.1717",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -64,6 +64,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
@@ -311,6 +312,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2021.09.0+351",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -67,6 +67,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2022.02.0+443",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
@@ -359,6 +360,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2022.02.0+443",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/core-latest-daily.json
+++ b/stacks/core-latest-daily.json
@@ -27,6 +27,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "daily",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -51,6 +51,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2022.02.0+443",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
@@ -271,6 +272,7 @@
         "S6_VERSION": "v2.1.0.2",
         "RSTUDIO_VERSION": "2022.02.0+443",
         "DEFAULT_USER": "rstudio",
+        "PANDOC_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [


### PR DESCRIPTION
I noticed that it is set in the Dockerfile of other images such as `rocker/shiny` but not `rocker/rstudio` and `rocker/ml:cuda11.1`, so I will add it.
Without this environment variable, pandoc is not installed by apt because these images use RStudio bundled version, so we cannot confirm from the reports that pandoc is already installed.