### PR TITLE
Add prefix "R-" to the `org.opencontainers.image.version` annotation

### DIFF
--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -39,7 +39,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.0"
@@ -61,7 +61,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.0"
@@ -83,7 +83,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.0"
@@ -105,7 +105,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.0"
@@ -127,7 +127,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.0"
@@ -149,7 +149,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.0"
@@ -171,7 +171,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.0"
@@ -193,7 +193,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.0"
@@ -215,7 +215,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.0-cuda10.1",
@@ -239,7 +239,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.0-cuda10.1",
@@ -262,7 +262,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.0",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.0-cuda10.1",
@@ -285,7 +285,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:bionic",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.0-ubuntu18.04"
@@ -307,7 +307,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.0-ubuntu18.04",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.0-ubuntu18.04"
@@ -329,7 +329,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.0-ubuntu18.04",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.0-ubuntu18.04"
@@ -351,7 +351,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.0-ubuntu18.04",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.0-ubuntu18.04"
@@ -373,7 +373,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.0-ubuntu18.04",
-        "org.opencontainers.image.version": "4.0.0"
+        "org.opencontainers.image.version": "R-4.0.0"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.0-ubuntu18.04"

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -16,7 +16,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.1"
@@ -38,7 +38,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.1"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.1"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.1"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.1"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.1"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.1"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.1"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.1-cuda10.1",
@@ -216,7 +216,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.1-cuda10.1",
@@ -239,7 +239,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.1",
-        "org.opencontainers.image.version": "4.0.1"
+        "org.opencontainers.image.version": "R-4.0.1"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.1-cuda10.1",

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -16,7 +16,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.2"
@@ -38,7 +38,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.2"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.2"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.2"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.2"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.2"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.2"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.2"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.2-cuda10.1",
@@ -216,7 +216,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.2-cuda10.1",
@@ -239,7 +239,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.2",
-        "org.opencontainers.image.version": "4.0.2"
+        "org.opencontainers.image.version": "R-4.0.2"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.2-cuda10.1",

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -16,7 +16,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.3"
@@ -38,7 +38,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.3"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.3"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.3"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.3"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.3"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.3"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.3"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.3-cuda10.1",
@@ -216,7 +216,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.3-cuda10.1",
@@ -239,7 +239,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.3-cuda10.1",
@@ -262,7 +262,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.3",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.3-cuda11.1",
@@ -285,7 +285,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.3-cuda11.1",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.3-cuda11.1"
@@ -307,7 +307,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.3-cuda11.1",
-        "org.opencontainers.image.version": "4.0.3"
+        "org.opencontainers.image.version": "R-4.0.3"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.3-cuda11.1"

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -16,7 +16,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.4"
@@ -38,7 +38,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.4"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.4"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.4"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.4"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.4"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.4"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.4"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.4-cuda10.1",
@@ -216,7 +216,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.4-cuda10.1",
@@ -239,7 +239,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.4-cuda10.1",
@@ -262,7 +262,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.4",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.4-cuda11.1",
@@ -285,7 +285,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.4-cuda11.1",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.4-cuda11.1"
@@ -307,7 +307,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.4-cuda11.1",
-        "org.opencontainers.image.version": "4.0.4"
+        "org.opencontainers.image.version": "R-4.0.4"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.4-cuda11.1"

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -16,7 +16,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.0.5",
@@ -39,7 +39,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.0.5",
@@ -62,7 +62,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.0.5",
@@ -85,7 +85,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/verse:4.0.5",
@@ -108,7 +108,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.0.5",
@@ -131,7 +131,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/shiny:4.0.5",
@@ -154,7 +154,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.0.5",
@@ -177,7 +177,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/binder:4.0.5",
@@ -200,7 +200,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.5-cuda10.1",
@@ -226,7 +226,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.5-cuda10.1",
@@ -251,7 +251,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.5-cuda10.1",
@@ -276,7 +276,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.0.5",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/cuda:4.0.5-cuda11.1",
@@ -300,7 +300,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.0.5-cuda11.1",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/ml:4.0.5-cuda11.1",
@@ -323,7 +323,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.0.5-cuda11.1",
-        "org.opencontainers.image.version": "4.0.5"
+        "org.opencontainers.image.version": "R-4.0.5"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.0.5-cuda11.1",

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -37,7 +37,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.1.0"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.1.0"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.1.0"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/verse:4.1.0"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.1.0"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/shiny:4.1.0"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.1.0"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/binder:4.1.0"
@@ -214,7 +214,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.0-cuda10.1",
@@ -238,7 +238,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.0-cuda10.1",
@@ -261,7 +261,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.0",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.0-cuda10.1",
@@ -284,7 +284,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.0-cuda11.1",
@@ -307,7 +307,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.0-cuda11.1",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.0-cuda11.1"
@@ -329,7 +329,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.0-cuda11.1",
-        "org.opencontainers.image.version": "4.1.0"
+        "org.opencontainers.image.version": "R-4.1.0"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.0-cuda11.1"

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -37,7 +37,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.1.1"
@@ -60,7 +60,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.1.1"
@@ -82,7 +82,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.1.1"
@@ -104,7 +104,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/verse:4.1.1"
@@ -126,7 +126,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.1.1"
@@ -148,7 +148,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/shiny:4.1.1"
@@ -170,7 +170,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.1.1"
@@ -192,7 +192,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/binder:4.1.1"
@@ -214,7 +214,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.1-cuda10.1",
@@ -238,7 +238,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.1-cuda10.1",
@@ -261,7 +261,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.1-cuda10.1",
@@ -284,7 +284,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.1-cuda11.1",
@@ -307,7 +307,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.1-cuda11.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.1-cuda11.1"
@@ -329,7 +329,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.1-cuda11.1",
-        "org.opencontainers.image.version": "4.1.1"
+        "org.opencontainers.image.version": "R-4.1.1"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.1-cuda11.1"

--- a/bakefiles/4.1.2.docker-bake.json
+++ b/bakefiles/4.1.2.docker-bake.json
@@ -37,7 +37,7 @@
         "org.opencontainers.image.title": "rocker/r-ver",
         "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/library/ubuntu:focal",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/r-ver:4.1.2",
@@ -63,7 +63,7 @@
         "org.opencontainers.image.title": "rocker/rstudio",
         "org.opencontainers.image.description": "RStudio Server with fixed version of R",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/rstudio:4.1.2",
@@ -88,7 +88,7 @@
         "org.opencontainers.image.title": "rocker/tidyverse",
         "org.opencontainers.image.description": "Version-stable build of R, RStudio Server, and R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/rstudio:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.1.2",
@@ -113,7 +113,7 @@
         "org.opencontainers.image.title": "rocker/verse",
         "org.opencontainers.image.description": "Adds tex & related publishing packages to version-locked tidyverse image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/tidyverse:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/verse:4.1.2",
@@ -138,7 +138,7 @@
         "org.opencontainers.image.title": "rocker/geospatial",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.1.2",
@@ -163,7 +163,7 @@
         "org.opencontainers.image.title": "rocker/shiny",
         "org.opencontainers.image.description": "Shiny Server on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/shiny:4.1.2",
@@ -188,7 +188,7 @@
         "org.opencontainers.image.title": "rocker/shiny-verse",
         "org.opencontainers.image.description": "Rocker Shiny image + Tidyverse R packages. Uses version-stable image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/shiny:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.1.2",
@@ -213,7 +213,7 @@
         "org.opencontainers.image.title": "rocker/binder",
         "org.opencontainers.image.description": "Adds binder to rocker/geospatial, providing JupyterHub access on rocker containers.",
         "org.opencontainers.image.base.name": "docker.io/rocker/geospatial:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/binder:4.1.2",
@@ -238,7 +238,7 @@
         "org.opencontainers.image.title": "rocker/cuda",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/r-ver:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.2-cuda10.1",
@@ -268,7 +268,7 @@
         "org.opencontainers.image.title": "rocker/ml",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.2-cuda10.1",
@@ -297,7 +297,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.2-cuda10.1",
@@ -326,7 +326,7 @@
         "org.opencontainers.image.title": "rocker/cuda (CUDA 11)",
         "org.opencontainers.image.description": "NVIDIA CUDA libraries added to Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.2-cuda11.1",
@@ -352,7 +352,7 @@
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries.",
         "org.opencontainers.image.base.name": "docker.io/rocker/cuda:4.1.2-cuda11.1",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/ml:4.1.2-cuda11.1",
@@ -377,7 +377,7 @@
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",
         "org.opencontainers.image.description": "Docker image with R + GPU support for machine learning libraries, and many R packages.",
         "org.opencontainers.image.base.name": "docker.io/rocker/ml:4.1.2-cuda11.1",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.2-cuda11.1",

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -25,7 +25,7 @@
         "org.opencontainers.image.title": "rocker/geospatial (ubuntugis)",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/geospatial:4.1.2-ubuntugis",
@@ -48,7 +48,7 @@
         "org.opencontainers.image.title": "rocker/geospatial (dev-osgeo)",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.1.2",
-        "org.opencontainers.image.version": "4.1.2"
+        "org.opencontainers.image.version": "R-4.1.2"
       },
       "tags": [
         "docker.io/rocker/geospatial:dev-osgeo"

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -22,7 +22,7 @@ library(stringr)
 
 .version_or_null <- function(tag) {
   if (stringr::str_detect(tag, "^\\d+\\.\\d+\\.\\d+$")) {
-    return(tag)
+    return(stringr::str_c("R-", tag))
   } else {
     return(NULL)
   }


### PR DESCRIPTION
Add prefix `R-` to `org.opencontainers.image.version`, which represents the major software included in the image, whereas up to now it has listed just the version without prefix.
https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

For example, the content of the `org.opencontainers.image.version` annotation of `tonistiigi/binfmt:latest`, which used for multi-platform builds in GitHub Actions, is `qemu-v6.1.0-21`.
https://github.com/rocker-org/rocker-versioned2/runs/5355027888?check_suite_focus=true#step:4:172