### PR TITLE
Add new editorconfig rules for shell script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,8 @@
 indent_style = space
 indent_size = 2
 insert_final_newline = true
+
+[*.sh]
+indent_style = space
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
The super-linter configured in #323 includes an auto-formatter for shell scripts called [shfmt](https://github.com/mvdan/sh).
shfmt seems to expect the indentation to be tab by default when executed in the CLI.
However, the shell scripts included in this repository have tabs set to 4 spaces (which is also the general style), so set them as such in the `.editorconfig` file [referenced by shfmt](https://github.com/mvdan/sh/issues/393).