### PR TITLE
Support RStudio's new bundled pandoc path (quarto v0.9.191)

### DIFF
--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -26,6 +26,8 @@ if [ -f "/usr/lib/rstudio-server/bin/pandoc/pandoc" ]; then
     BUNDLED_PANDOC="/usr/lib/rstudio-server/bin/pandoc/pandoc"
 elif [ -f "/usr/lib/rstudio-server/bin/quarto/bin/pandoc" ]; then
     BUNDLED_PANDOC="/usr/lib/rstudio-server/bin/quarto/bin/pandoc"
+elif [ -f "/usr/lib/rstudio-server/bin/quarto/bin/tools/pandoc" ]; then
+    BUNDLED_PANDOC="/usr/lib/rstudio-server/bin/quarto/bin/tools/pandoc"
 fi
 
 if [ -n "$BUNDLED_PANDOC" ]; then


### PR DESCRIPTION
The pandoc path has been changed in the latest version of quarto. (quarto-dev/quarto-cli#545)
This change should eventually be reflected in the quarto bundled with RStudio. (rstudio/rstudio#10952)

```shell
$ ls /opt/quarto/bin/
quarto  quarto.js  tools
$ ls /opt/quarto/bin/tools/
dart-sass  deno  deno_dom  esbuild  pandoc
```