### PR TITLE
[CI] Divide the reporting job into groups

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          CONTENT=$(jq '{ group: [.group[] | keys[] | select(. != "default")] }' -r bakefiles/extra.docker-bake.json)
-          echo ::set-output name=matrix::${CONTENT}
-          echo ${CONTENT}
+          CONTENT=$(jq '{ group: [.group[] | keys[] | select(. != "default")] } | tostring' -r bakefiles/extra.docker-bake.json)
+          echo ::set-output name=matrix::"${CONTENT}"
+          echo "${CONTENT}"
 
   build:
     needs: generate_matrix

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          CONTENT=$(jq '{ group: [.group[] | keys[]] }' -r bakefiles/extra.docker-bake.json)
+          CONTENT=$(jq '{ group: [.group[] | keys[] | select(. != "default")] }' -r bakefiles/extra.docker-bake.json)
           echo ::set-output name=matrix::${CONTENT}
           echo ${CONTENT}
 

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -26,8 +26,8 @@ jobs:
       - id: set-matrix
         run: |
           CONTENT=$(jq -r '.r_version += ["extra"]' build/matrix/all.json)
-          echo ::set-output name=matrix::${CONTENT}
-          echo ${CONTENT}
+          echo ::set-output name=matrix::"${CONTENT}"
+          echo "${CONTENT}"
 
   inspect:
     needs: generate_matrix
@@ -42,13 +42,12 @@ jobs:
           docker image prune --all --force
       - name: Pull images
         run: |
-          BAKE_JSON=bakefiles/${{ matrix.r_version }}.docker-bake.json \
-          BAKE_GROUP=${{ matrix.group }} \
+          BAKE_JSON="bakefiles/${{ matrix.r_version }}.docker-bake.json" \
+          BAKE_GROUP="${{ matrix.group }}" \
           make pull-image-group
       - name: Inspect built image
         run: |
-          IMAGELIST_NAME=${{ matrix.r_version }}-${{ matrix.group }}.tsv \
-          IMAGE_FILTER= \
+          IMAGELIST_NAME="${{ matrix.r_version }}-${{ matrix.group }}.tsv" \
           make inspect-image-all
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          CONTENT=$(jq -r '.r_version += ["extra"]' build/matrix/all.json)
+          CONTENT=$(jq -r '.r_version += ["extra"] | tostring' build/matrix/all.json)
           echo ::set-output name=matrix::"${CONTENT}"
           echo "${CONTENT}"
 

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          CONTENT=$(jq -r 'with_entries(select(.key == "r_version")) | .r_version += ["extra"]' build/matrix/all.json)
+          CONTENT=$(jq -r '.r_version += ["extra"]' build/matrix/all.json)
           echo ::set-output name=matrix::${CONTENT}
           echo ${CONTENT}
 
@@ -42,10 +42,14 @@ jobs:
           docker image prune --all --force
       - name: Pull images
         run: |
-          BAKE_JSON=bakefiles/${{ matrix.r_version }}.docker-bake.json make pull-image-all
+          BAKE_JSON=bakefiles/${{ matrix.r_version }}.docker-bake.json \
+          BAKE_GROUP=${{ matrix.group }} \
+          make pull-image-group
       - name: Inspect built image
         run: |
-          IMAGELIST_NAME=${{ matrix.r_version }}.tsv IMAGE_FILTER= make inspect-image-all
+          IMAGELIST_NAME=${{ matrix.r_version }}-${{ matrix.group }}.tsv \
+          IMAGE_FILTER= \
+          make inspect-image-all
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -66,6 +70,9 @@ jobs:
         with:
           repository: "${{ github.repository }}.wiki"
           path: reports
+      - name: clean up image list
+        run:
+          rm -rf reports/imagelist
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -1,6 +1,14 @@
 {
   "group": [
     {
+      "default": [
+        {
+          "targets": [
+            "geospatial-ubuntugis",
+            "geospatial-dev-osgeo"
+          ]
+        }
+      ],
       "ubuntugis": [
         {
           "targets": [

--- a/stacks/extra.json
+++ b/stacks/extra.json
@@ -4,6 +4,14 @@
   "LABEL": "org.opencontainers.image.licenses=\"GPL-2.0-or-later\" \\\n      org.opencontainers.image.source=\"https://github.com/rocker-org/rocker-versioned2\" \\\n      org.opencontainers.image.vendor=\"Rocker Project\" \\\n      org.opencontainers.image.authors=\"Carl Boettiger <cboettig@ropensci.org>\"",
   "group": [
     {
+      "default": [
+        {
+          "targets": [
+            "geospatial-ubuntugis",
+            "geospatial-dev-osgeo"
+          ]
+        }
+      ],
       "ubuntugis": [
         {
           "targets": [


### PR DESCRIPTION
Close #403

Add a target `make pull-image-group` to pull only images belonging to a specific group of `docker-bake.json` and update the GitHubActions reporting workflow to use this job.

Note that buildx v0.8 is required for operation as it assumes that the `docker buildx bake --print` command works properly.

**ToDo**

- [x] Add `extra`'s default group.
- [x] Test on my fork.
  - [x] extra.yml <https://github.com/eitsupi/rocker-versioned2/actions/runs/2140384814>  
  The modified matrix is functioning properly, although I have not actually built it because I have failed to log in to DockerHub.  
  ![image](https://user-images.githubusercontent.com/50911393/162601558-7dce7a80-cb9f-4537-a3a5-9de1537136fb.png)
  - [x] reports.yml <https://github.com/eitsupi/rocker-versioned2/actions/runs/2140345167>  
  ![image](https://user-images.githubusercontent.com/50911393/162601546-9a0d4785-27e4-4360-be87-c7bcdfbea0fe.png)