### PR TITLE
[CI] More Rocker scripts to test

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -8,10 +8,14 @@ on:
       - tests/rocker_scripts/Dockerfile
       - tests/rocker_scripts/matrix.json
       - tests/rocker_scripts/test.sh
+      - scripts/install_s6init.sh
       - scripts/install_rstudio.sh
       - scripts/install_pandoc.sh
+      - scripts/install_shiny_server.sh
       - scripts/install_tidyverse.sh
       - scripts/install_verse.sh
+      - scripts/install_geospatial.sh
+      - scripts/install_wgrib2.sh
   workflow_dispatch:
 
 jobs:
@@ -35,12 +39,12 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: test build
         run: |
-          docker build . -f tests/rocker_scripts/Dockerfile \
-          -t rocker-script-test \
+          docker buildx build . -f tests/rocker_scripts/Dockerfile \
+          --output=type=docker \
           --build-arg tag=${{ matrix.tag }} \
-          --build-arg rstudio=${{ matrix.rstudio }} \
-          --build-arg pandoc=${{ matrix.pandoc }} \
-          --build-arg tidyverse=${{ matrix.tidyverse }} \
-          --build-arg verse=${{ matrix.verse }}
+          --build-arg script_name=${{ matrix.script_name }} \
+          --build-arg script_arg=${{ matrix.script_arg }}

--- a/tests/rocker_scripts/Dockerfile
+++ b/tests/rocker_scripts/Dockerfile
@@ -1,17 +1,9 @@
 ARG tag=latest
 FROM rocker/r-ver:${tag}
 
-COPY scripts /rocker_scripts
 COPY tests/rocker_scripts/test.sh /test.sh
+COPY scripts /rocker_scripts
 
-ARG rstudio=skip
-RUN /test.sh install_rstudio.sh $rstudio
-
-ARG pandoc=skip
-RUN /test.sh install_pandoc.sh $pandoc
-
-ARG tidyverse=skip
-RUN /test.sh install_tidyverse.sh $tidyverse
-
-ARG verse=skip
-RUN /test.sh install_verse.sh $verse
+ARG script_name=install_rstudio.sh
+ARG script_arg=skip
+RUN /test.sh ${script_name} ${script_arg}

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -3,26 +3,22 @@
     "4.0.0",
     "latest"
   ],
-  "rstudio": [
-    "skip",
-    "latest"
+  "script_name": [
+    "install_rstudio.sh",
+    "install_pandoc.sh",
+    "install_tidyverse.sh",
+    "install_verse.sh",
+    "install_shiny_server.sh",
+    "install_geospatial.sh"
   ],
-  "pandoc": [
-    "skip",
-    "default"
-  ],
-  "tidyverse": [
-    "skip",
-    "none"
-  ],
-  "verse": [
+  "script_arg": [
     "none"
   ],
   "include": [
     {
       "tag": "4.0.0",
-      "rstudio": "1.3.959",
-      "pandoc": "default"
+      "script_name": "install_rstudio.sh",
+      "script_arg": "1.3.959"
     }
   ]
 }


### PR DESCRIPTION
Related to #282

We need to remove apt packages that do not exist for `ubuntu:jammy` from Rocker scripts in the near future.
For such work, it would be useful if testing could be done automatically.

Although I have made it possible to test the case where each script is combined in #392, there is no need to combine them since the Rocker scripts must actually be able to be executed on their own.
In this PR, I will review the matrix configuration and focus on single script execution.
