### PR TITLE
Remove unused `libgc1c2` in `install_rstudio.sh`

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -17,7 +17,6 @@ apt-get install -y --no-install-recommends \
     file \
     git \
     libapparmor1 \
-    libgc1c2 \
     libclang-dev \
     libcurl4-openssl-dev \
     libedit2 \


### PR DESCRIPTION
Close #408