### PR TITLE
[CI] Minor changes to make buildx cache work in tests for install R from source

### DIFF
--- a/.github/workflows/r-build-test.yml
+++ b/.github/workflows/r-build-test.yml
@@ -30,7 +30,7 @@ jobs:
           docker buildx bake \
           -f bakefiles/"${{ matrix.tag }}".docker-bake.json \
           --set=*.platform="${{ matrix.platforms }}" \
-          --set=*.cache-from=type=rocker/r-ver:"${{ matrix.tag }}" \
+          --set=*.cache-from=docker.io/rocker/r-ver:"${{ matrix.tag }}" \
           --set=*.cache-from=type=gha \
           --set=*.cache-to=type=gha \
           --set=r-ver.tags=r-ver-test-"${{ matrix.tag }}" \


### PR DESCRIPTION
I made a mistake in the syntax, so I'll fix it.

The correct syntax is one of the following:

```shell
docker buildx build --cache-from=user/app .
docker buildx build --cache-from=type=registry,ref=user/app .
```

<https://github.com/docker/buildx/blob/b8bcf1d810c754a696496d6ad05e34b699ad8af0/docs/reference/buildx_build.md#cache-from>