### PR TITLE
[CI] Use GHA cache in tests for installing R from source

### DIFF
--- a/.github/workflows/r-build-test.yml
+++ b/.github/workflows/r-build-test.yml
@@ -25,14 +25,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v1
       - name: test build
         run: |
           docker buildx bake \
           -f bakefiles/"${{ matrix.tag }}".docker-bake.json \
           --set=*.platform="${{ matrix.platforms }}" \
           --set=*.cache-from=docker.io/rocker/r-ver:"${{ matrix.tag }}" \
-          --set=*.cache-from=type=gha \
-          --set=*.cache-to=type=gha \
+          --set=*.cache-from=type=gha,scope=r-ver-"${{ matrix.tag }}" \
+          --set=*.cache-to=type=gha,scope=r-ver-"${{ matrix.tag }}" \
           --set=r-ver.tags=r-ver-test-"${{ matrix.tag }}" \
           --load \
           r-ver


### PR DESCRIPTION
Enable the GitHub Actions cache, which until now has not been working due to missing steps for authentication.

For more information, please refer to the following documents.
<https://github.com/moby/buildkit/blob/86c33b66e176a6fc74b88d6f46798d3ec18e2e73/README.md#github-actions-cache-experimental>