### PR TITLE
Remove `liblapack-dev` after R installation to reduce image size

### DIFF
--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -43,7 +43,6 @@ apt-get install -y --no-install-recommends \
     libbz2-* \
     libcurl4 \
     libicu* \
-    liblapack-dev \
     libpcre2* \
     libjpeg-turbo* \
     libpangocairo-* \
@@ -71,6 +70,7 @@ BUILDDEPS="curl \
     liblzma-dev \
     libx11-dev \
     libxt-dev \
+    liblapack-dev \
     perl \
     rsync \
     subversion \


### PR DESCRIPTION
Related to #390

In #386, the image size increased by 30MB as a result of the additional installation of `liblapack-dev`.
However, this appears to be acceptable to remove after R installation, so I would like to remove it and reduce the image size.