### PR TITLE
Fix default locale settings

### DIFF
--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -15,9 +15,10 @@ R_VERSION=${1:-${R_VERSION:-"latest"}}
 apt-get update
 apt-get -y install locales lsb-release
 
-## Configure default locale, see https://github.com/docker-library/docs/tree/master/ubuntu#locales
-localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+## Configure default locale
 LANG=${LANG:-"en_US.UTF-8"}
+/usr/sbin/locale-gen --lang "${LANG}"
+/usr/sbin/update-locale --reset LANG="${LANG}"
 
 UBUNTU_VERSION=$(lsb_release -sc)
 

--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -6,7 +6,7 @@
 ## ex. latest, devel, patched, 4.0.0
 ##
 ## 'devel' means the prerelease development version (Latest daily snapshot of development version).
-## 'pached' means the prerelease patched version (Latest daily snapshot of pached version).
+## 'patched' means the prerelease patched version (Latest daily snapshot of patched version).
 
 set -e
 

--- a/scripts/setup_R.sh
+++ b/scripts/setup_R.sh
@@ -72,7 +72,16 @@ else
     ln -sf "${R_HOME}/site-library/littler/examples/install2.r" /usr/local/bin/install2.r
 fi
 
-r --version
-
 # Clean up
 rm -rf /var/lib/apt/lists/*
+
+# Check the R info
+echo -e "Check the littler info...\n"
+
+r --version
+
+echo -e "Check the R info...\n"
+
+R -q -e "sessionInfo()"
+
+echo -e "Setup R, done!"


### PR DESCRIPTION
Fix #397

The change in #313 results in the deletion of the `update-locale` process, which causes the problem with Shiny Server.
This PR will re-correct how the locale is set up.

Note: The LANG environment variable is set after the execution of `install_R_source.sh`, since setting the LANG environment variable before installing the `locales` package would result in a warning (as described in https://github.com/rocker-org/rocker-versioned2/issues/302#issuecomment-997437630).