### PR TITLE
[CI] Temporarily pin the container version in workflows not to use latest git version

### DIFF
--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: rocker/tidyverse:latest
+      image: rocker/tidyverse@sha256:84363da59e10b3bf14e2db6db9aaf213d281b15b00518e93be70661aaa98847e
     steps:
       - uses: actions/checkout@v3
       - name: install packages

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -60,7 +60,7 @@ jobs:
     needs: inspect
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse:latest
+      image: rocker/tidyverse@sha256:84363da59e10b3bf14e2db6db9aaf213d281b15b00518e93be70661aaa98847e
     steps:
       - name: Checkout main
         uses: actions/checkout@v3


### PR DESCRIPTION
Fix #420

When using the latest Git for ubuntu `1:2.25.1-1ubuntu3.3`, the checkout action used on the Docker container does not work now.
To work around this, temporarily pin the container to images which have Git `1:2.25.1-1ubuntu3.2` as the container to be used within the workflow.
Pin to this image. https://github.com/rocker-org/rocker-versioned2/wiki/tidyverse_c6e6e5a1e3c8

After the checkout action is updated, this commit must be revert.