### PR TITLE
Change the rule for selecting Ubuntu version of base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Compared to `r-base`, this stack:
 
 - Builds on Ubuntu LTS rather than Debian and system libraries are tied to the Ubuntu version.
   Images will use the most recent LTS available at the time when the corresponding R version was released.
-  Thus all 4.0 images are based on Ubuntu 20.04 (`ubuntu:focal`).
+  - Since compatibility problems are likely to occur immediately after the release of a new Ubuntu LTS,
+    the version to be used is the one that is at least 90 days past release.
+    - `rocker/r-ver:4.0.0` is based on Ubuntu 20.04 (`ubuntu:focal`)
+      because no interval was set at the time of the Ubuntu 20.04 release.
 - Installs a fixed version of R itself from source, rather than whatever is already packaged for Ubuntu
   (the `r-base` stack gets the latest R version as a binary from Debian unstable).
 - The only platforms available are `linux/amd64` and `linux/arm64`

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -441,7 +441,7 @@ df_rstudio <- gert::git_remote_ls(remote = "https://github.com/rstudio/rstudio.g
 
 df_args <- df_r |>
   tidyr::expand_grid(df_ubuntu_lts) |>
-  dplyr::filter(r_release_date >= ubuntu_release_date) |>
+  dplyr::filter(r_release_date >= ubuntu_release_date + 90) |>
   dplyr::group_by(r_version) |>
   dplyr::slice_max(ubuntu_release_date, with_ties = FALSE) |>
   dplyr::ungroup() |>

--- a/build/reports/versions.Rmd
+++ b/build/reports/versions.Rmd
@@ -33,7 +33,9 @@ For information about old images with 3.X.X tags, please check [the `rocker-org/
 
 ## Rules
 
-- Ubuntu version is the latest Ubuntu LTS version when that R version was released.
+- For the base image, select the latest Ubuntu LTS version that is more than 90 days old at the release date of that R version.
+  - The images for R 4.0.0 and R 4.0.1, which were released within 90 days of the release of Ubuntu 20.04,
+  are based on Ubuntu 20.04 because the latest Ubuntu LTS was selected without setting an interval at that time.
 - CRAN date is the date of the last CRAN snapshot in the era when that R version was the latest.
   - If that R version is the latest, the CRAN date will not be set and the latest packages will always be installed.
 - RStudio version is the latest stable RStudio version of the era when that R version was the latest.


### PR DESCRIPTION
Related to #282

Since RStudio and others may not be able to support the new LTS version of Ubuntu immediately after its release, a 90-day grace period will be set so that Ubuntu will not be set as the base image immediately after its release.