### PR TITLE
[CI] Enable inline cache for all images

### DIFF
--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -73,7 +73,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -95,7 +95,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -117,7 +117,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -139,7 +139,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -161,7 +161,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -183,7 +183,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -205,7 +205,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -229,7 +229,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -252,7 +252,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -275,7 +275,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "r-ver-bionic": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse-bionic": {
@@ -341,7 +341,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse-bionic": {
@@ -363,7 +363,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial-bionic": {
@@ -385,7 +385,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -50,7 +50,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -206,7 +206,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -229,7 +229,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -252,7 +252,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -50,7 +50,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -206,7 +206,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -229,7 +229,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -252,7 +252,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -50,7 +50,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -206,7 +206,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -229,7 +229,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -252,7 +252,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -275,7 +275,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-cuda11": {
@@ -297,7 +297,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -50,7 +50,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -206,7 +206,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -229,7 +229,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -252,7 +252,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -275,7 +275,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-cuda11": {
@@ -297,7 +297,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -52,7 +52,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -75,7 +75,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -98,7 +98,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -121,7 +121,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -144,7 +144,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -167,7 +167,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -190,7 +190,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -216,7 +216,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -241,7 +241,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -266,7 +266,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -290,7 +290,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-cuda11": {
@@ -313,7 +313,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -336,7 +336,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -204,7 +204,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -228,7 +228,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -251,7 +251,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -274,7 +274,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -341,7 +341,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -204,7 +204,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -228,7 +228,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -251,7 +251,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -274,7 +274,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -341,7 +341,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.1.2.docker-bake.json
+++ b/bakefiles/4.1.2.docker-bake.json
@@ -72,7 +72,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -94,7 +94,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -138,7 +138,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -160,7 +160,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -182,7 +182,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -204,7 +204,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -228,7 +228,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -251,7 +251,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -274,7 +274,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -319,7 +319,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -341,7 +341,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/4.1.3.docker-bake.json
+++ b/bakefiles/4.1.3.docker-bake.json
@@ -78,7 +78,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -103,7 +103,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -128,7 +128,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -153,7 +153,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -178,7 +178,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -203,7 +203,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -228,7 +228,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -258,7 +258,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -287,7 +287,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -316,7 +316,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -367,7 +367,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -392,7 +392,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/core-latest-daily.docker-bake.json
+++ b/bakefiles/core-latest-daily.docker-bake.json
@@ -31,7 +31,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -52,7 +52,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -73,7 +73,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/devel.docker-bake.json
+++ b/bakefiles/devel.docker-bake.json
@@ -32,7 +32,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "rstudio": {
@@ -53,7 +53,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "tidyverse": {
@@ -74,7 +74,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "verse": {
@@ -95,7 +95,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial": {
@@ -116,7 +116,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny": {
@@ -137,7 +137,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "shiny-verse": {
@@ -158,7 +158,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "binder": {
@@ -179,7 +179,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda": {
@@ -202,7 +202,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml": {
@@ -224,7 +224,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse": {
@@ -246,7 +246,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "cuda11": {
@@ -268,7 +268,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-cuda11": {
@@ -289,7 +289,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "ml-verse-cuda11": {
@@ -310,7 +310,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -46,7 +46,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     },
     "geospatial-dev-osgeo": {
@@ -68,7 +68,7 @@
         ""
       ],
       "cache-to": [
-        ""
+        "type=inline"
       ]
     }
   }

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -9,7 +9,7 @@ library(stringr)
 
 .image_full_name <- function(image_name) {
   full_name <- dplyr::case_when(
-    stringr::str_detect(image_name, "^.+\\..+/.+/.+") ~ image_name,
+    stringr::str_detect(image_name, r"(^.+\..+/.+/.+)") ~ image_name,
     stringr::str_count(image_name, "/") == 0 ~ stringr::str_c("docker.io/library/", image_name),
     stringr::str_count(image_name, "/") == 1 ~ stringr::str_c("docker.io/", image_name)
   )
@@ -21,7 +21,7 @@ library(stringr)
 
 
 .version_or_null <- function(tag) {
-  if (stringr::str_detect(tag, "^\\d+\\.\\d+\\.\\d+$")) {
+  if (stringr::str_detect(tag, r"(^\d+\.\d+\.\d+$)")) {
     return(stringr::str_c("R-", tag))
   } else {
     return(NULL)
@@ -29,36 +29,36 @@ library(stringr)
 }
 
 
-.bake_list <- function(stack_file) {
-  stack_content <- jsonlite::read_json(stack_file)
+.bake_list <- function(stack_file_path) {
+  stack_content <- jsonlite::read_json(stack_file_path)
 
   stack_tag <- stack_content$TAG
 
-  content_list <- stack_content$stack %>%
-    tibble::enframe() %>%
+  df_content <- stack_content$stack |>
+    tibble::enframe() |>
     dplyr::transmute(
       name = purrr::map_chr(value, "IMAGE", .default = NA),
       context = "./",
-      dockerfile = paste0("dockerfiles/", name, "_", stack_tag, ".Dockerfile"),
+      dockerfile = stringr::str_c("dockerfiles/", name, "_", stack_tag, ".Dockerfile"),
       labels = purrr::map(value, "labels"),
       tags = purrr::map(
         value,
-        ~ if (!is.null(.x$tags)) .x$tags else list(paste0("docker.io/rocker/", .x$IMAGE, ":", stack_tag))
+        ~ if (!is.null(.x$tags)) .x$tags else list(stringr::str_c("docker.io/rocker/", .x$IMAGE, ":", stack_tag))
       ),
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64")),
       `cache-from` = purrr::map(value, "cache-from", .default = list("")),
       `cache-to` = purrr::map(value, "cache-to", .default = list("")),
       base_image = map_chr(value, "FROM")
-    ) %>%
-    dplyr::rowwise() %>%
+    ) |>
+    dplyr::rowwise() |>
     dplyr::mutate(
       labels = list(purrr::list_modify(
         labels,
         org.opencontainers.image.base.name = .image_full_name(base_image),
         org.opencontainers.image.version = .version_or_null(stack_tag)
       ))
-    ) %>%
-    dplyr::ungroup() %>%
+    ) |>
+    dplyr::ungroup() |>
     dplyr::select(
       name,
       context,
@@ -68,28 +68,31 @@ library(stringr)
       platforms,
       `cache-from`,
       `cache-to`
-    ) %>%
-    {
-      list(
-        group = if (!is.null(stack_content$group)) {
-          stack_content$group
-        } else {
-          list(c(list(default = list(c(list(targets = if (length(.$name) == 1) list(.$name) else c(.$name)))))))
-        },
-        target = purrr::transpose(dplyr::select(., !name), .names = .$name)
-      )
-    }
+    )
 
-  return(content_list)
+  list_content <- list(
+    group = if (!is.null(stack_content$group)) {
+      stack_content$group
+    } else {
+      list(c(list(
+        default = list(c(list(
+          targets = if (length(df_content$name) == 1) list(df_content$name) else c(df_content$name)
+        )))
+      )))
+    },
+    target = purrr::transpose(dplyr::select(df_content, !name), .names = df_content$name)
+  )
+
+  return(list_content)
 }
 
 
-write_bakejson <- function(stack_file) {
-  output_path <- sub("^stacks/", "bakefiles/", stack_file) %>% {
-    sub(".json$", ".docker-bake.json", .)
-  }
+write_bakejson <- function(stack_file_path) {
+  output_path <- stack_file_path |>
+    stringr::str_replace("^stacks/", "bakefiles/") |>
+    stringr::str_replace(".json$", ".docker-bake.json")
 
-  .bake_list(stack_file) %>%
+  .bake_list(stack_file_path) |>
     jsonlite::write_json(output_path, pretty = TRUE, auto_unbox = TRUE)
 
   message(output_path)
@@ -98,7 +101,7 @@ write_bakejson <- function(stack_file) {
 
 message("\nstart writing docker-bake.json files.")
 
-list.files(path = "stacks", pattern = "\\.json$", full.names = TRUE) %>%
+list.files(path = "stacks", pattern = "\\.json$", full.names = TRUE) |>
   purrr::walk(write_bakejson)
 
 message("make-bakejson.R done!\n")

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -47,7 +47,7 @@ library(stringr)
       ),
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64")),
       `cache-from` = purrr::map(value, "cache-from", .default = list("")),
-      `cache-to` = purrr::map(value, "cache-to", .default = list("")),
+      `cache-to` = purrr::map(value, "cache-to", .default = list("type=inline")),
       base_image = map_chr(value, "FROM")
     ) |>
     dplyr::rowwise() |>


### PR DESCRIPTION
The cache exporting enabled only for `rocker/r-ver` by #274 seems to work well.

Since inline caching does not seem to have any disadvantages, such as increasing image size, I would like to enable inline caching for all images.