### PR TITLE
Fix the path of the Binder deployment

### DIFF
--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -16,6 +16,8 @@ usermod -l "${NB_USER}" "${DEFAULT_USER}"
 mkdir -p "${PYTHON_VENV_PATH}"
 chown -R "${NB_USER}" "${PYTHON_VENV_PATH}"
 
+PATH=/opt/pyenv/bin:${PATH}
+
 # And set ENV for R! It doesn't read from the environment...
 echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
 echo "export PATH=${PATH}" >>"${WORKDIR}/.profile"


### PR DESCRIPTION
Add `/opt/pyenv/bin` to the `.profile` PATH definition for the Binder deployment, it was triggering a warning in the terminal

The issue has been discussed here in https://github.com/rocker-org/rocker-versioned2/issues/428