### PR TITLE
[CI] [Reports] Don't delete image lists to avoid erasing information of old groups

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -69,9 +69,9 @@ jobs:
         with:
           repository: "${{ github.repository }}.wiki"
           path: reports
-      - name: clean up image list
-        run:
-          rm -rf reports/imagelist
+      # - name: clean up image list
+      #   run:
+      #     rm -rf reports/imagelist
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The `bionicimages` group of 4.0.0 has been deleted by #436.
However, if we do not delete the image lists from the wiki, the information on the last built images can be referenced from the wiki.
(I meant to make this change in #436 and forgot)