### PR TITLE
Allows `install_binder.sh` to be independently executable

### DIFF
--- a/dockerfiles/binder_4.0.0.Dockerfile
+++ b/dockerfiles/binder_4.0.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.1.Dockerfile
+++ b/dockerfiles/binder_4.0.1.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.2.Dockerfile
+++ b/dockerfiles/binder_4.0.2.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.3.Dockerfile
+++ b/dockerfiles/binder_4.0.3.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.4.Dockerfile
+++ b/dockerfiles/binder_4.0.4.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.5.Dockerfile
+++ b/dockerfiles/binder_4.0.5.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.0.Dockerfile
+++ b/dockerfiles/binder_4.1.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.1.Dockerfile
+++ b/dockerfiles/binder_4.1.1.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.2.Dockerfile
+++ b/dockerfiles/binder_4.1.2.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.3.Dockerfile
+++ b/dockerfiles/binder_4.1.3.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.0.Dockerfile
+++ b/dockerfiles/binder_4.2.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_devel.Dockerfile
+++ b/dockerfiles/binder_devel.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -27,5 +27,7 @@ if [ -x "$(command -v shiny-server)" ]; then
 fi
 
 ## configure git not to request password each time
-git config --system credential.helper 'cache --timeout=3600'
-git config --system push.default simple
+if [ -x "$(command -v git)" ]; then
+    git config --system credential.helper 'cache --timeout=3600'
+    git config --system push.default simple
+fi

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -16,7 +16,9 @@ function apt_install() {
     fi
 }
 
-apt_install git sudo libzmq3-dev
+apt_install \
+    sudo \
+    libzmq3-dev
 
 # set up the default user if it does not exist
 if ! id -u "${NB_USER}" >/dev/null 2>&1; then

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -41,7 +41,8 @@ echo "export PATH=${PATH}" >>"${WORKDIR}/.profile"
 cd "${WORKDIR}"
 ## This gets run as user
 sudo -u "${NB_USER}" python3 -m venv "${PYTHON_VENV_PATH}"
-pip3 install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab >=2.0
+
+python3 -m pip install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab
 
 install2.r --error --skipinstalled -n "$NCPUS" remotes
 

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+## build ARGs
+NCPUS=${NCPUS:-"-1"}
+
 NB_USER=${NB_USER:-${DEFAULT_USER:-"rstudio"}}
 
 # a function to install apt packages only if they are not installed
@@ -41,8 +44,11 @@ cd "${WORKDIR}"
 sudo -u "${NB_USER}" python3 -m venv "${PYTHON_VENV_PATH}"
 pip3 install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab >=2.0
 
-R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
+install2.r --error --skipinstalled -n "$NCPUS" remotes
+
+R --quiet -e "remotes::install_github('IRkernel/IRkernel')"
 R --quiet -e "IRkernel::installspec(prefix='${PYTHON_VENV_PATH}')"
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/downloaded_packages

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -16,7 +16,7 @@ function apt_install() {
     fi
 }
 
-apt_install git sudo
+apt_install git sudo libzmq3-dev
 
 # set up the default user if it does not exist
 if ! id -u "${NB_USER}" >/dev/null 2>&1; then

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -3,6 +3,18 @@ set -e
 
 NB_USER=${NB_USER:-${DEFAULT_USER:-"rstudio"}}
 
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install git sudo
+
 # set up the default user if it does not exist
 if ! id -u "${NB_USER}" >/dev/null 2>&1; then
     /rocker_scripts/default_user.sh "${NB_USER}"
@@ -28,3 +40,6 @@ pip3 install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab >=2.0
 
 R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
 R --quiet -e "IRkernel::installspec(prefix='${PYTHON_VENV_PATH}')"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-## force install of last working version of rstudio, if necessary
-# RSTUDIO_VERSION=1.3.959 /rocker_scripts/install_rstudio.sh
+NB_USER=${NB_USER:-${DEFAULT_USER:-"rstudio"}}
 
-## NOTE: this runs as user NB_USER!
+# set up the default user if it does not exist
+if ! id -u "${NB_USER}" >/dev/null 2>&1; then
+    /rocker_scripts/default_user.sh "${NB_USER}"
+fi
+
 PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-/opt/venv/reticulate}
-DEFAULT_USER=${DEFAULT_USER:-rstudio}
-NB_USER=${NB_USER:-${DEFAULT_USER}}
-NB_UID=${NB_UID:-1000}
 WORKDIR=${WORKDIR:-/home/${NB_USER}}
-usermod -l "${NB_USER}" "${DEFAULT_USER}"
 # Create a venv dir owned by unprivileged user & set up notebook in it
 # This allows non-root to install python libraries if required
 mkdir -p "${PYTHON_VENV_PATH}"

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -20,6 +20,9 @@ if ! id -u "${NB_USER}" >/dev/null 2>&1; then
     /rocker_scripts/default_user.sh "${NB_USER}"
 fi
 
+# install python
+/rocker_scripts/install_python.sh
+
 PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-/opt/venv/reticulate}
 WORKDIR=${WORKDIR:-/home/${NB_USER}}
 # Create a venv dir owned by unprivileged user & set up notebook in it

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -33,10 +33,9 @@ WORKDIR=${WORKDIR:-/home/${NB_USER}}
 mkdir -p "${PYTHON_VENV_PATH}"
 chown -R "${NB_USER}" "${PYTHON_VENV_PATH}"
 
+# to use pyenv in a RStudio session, we need to include the PATH in the .profile file
+# https://github.com/rocker-org/rocker-versioned2/issues/428
 PATH=/opt/pyenv/bin:${PATH}
-
-# And set ENV for R! It doesn't read from the environment...
-echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
 echo "export PATH=${PATH}" >>"${WORKDIR}/.profile"
 
 cd "${WORKDIR}"

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -150,12 +150,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.0"

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.1"

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.2"

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.3"

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.4"

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -148,12 +148,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.5",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.0"

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.1"

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.2"

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -170,12 +170,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.3",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -184,12 +184,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.0",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -132,12 +132,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888
     },
     {

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -10,7 +10,10 @@
     "install_verse.sh",
     "install_quarto.sh",
     "install_shiny_server.sh",
-    "install_geospatial.sh"
+    "install_geospatial.sh",
+    "install_python.sh",
+    "install_binder.sh",
+    "install_julia.sh"
   ],
   "script_arg": [
     "none"


### PR DESCRIPTION
As mentioned in the following comment, currently `install_binder.sh` cannot be executed unless `install_python.sh` has been executed in advance.
This is different from the behavior of other installation scripts and should be changed so that it can be executed independently.
https://github.com/rocker-org/rocker-versioned2/pull/429#discussion_r855956332