### PR TITLE
Remove TERM=xterm from Dockerfiles' ENV

### DIFF
--- a/dockerfiles/cuda11_4.1.0.Dockerfile
+++ b/dockerfiles/cuda11_4.1.0.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.0
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/cuda11_4.1.1.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.1
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/cuda11_4.1.2.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.2
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/cuda11_4.1.3.Dockerfile
+++ b/dockerfiles/cuda11_4.1.3.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.3
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/cuda11_4.2.0.Dockerfile
+++ b/dockerfiles/cuda11_4.2.0.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.2.0
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/cuda11_devel.Dockerfile
+++ b/dockerfiles/cuda11_devel.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=devel
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf

--- a/dockerfiles/r-ver_4.0.0.Dockerfile
+++ b/dockerfiles/r-ver_4.0.0.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.0
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.0.1.Dockerfile
+++ b/dockerfiles/r-ver_4.0.1.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.1
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.0.2.Dockerfile
+++ b/dockerfiles/r-ver_4.0.2.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.2
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.0.3.Dockerfile
+++ b/dockerfiles/r-ver_4.0.3.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.3
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.0.4.Dockerfile
+++ b/dockerfiles/r-ver_4.0.4.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.4
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.0.5.Dockerfile
+++ b/dockerfiles/r-ver_4.0.5.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.0.5
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.1.0.Dockerfile
+++ b/dockerfiles/r-ver_4.1.0.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.0
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.1.1.Dockerfile
+++ b/dockerfiles/r-ver_4.1.1.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.1
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.1.2.Dockerfile
+++ b/dockerfiles/r-ver_4.1.2.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.2
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.1.3.Dockerfile
+++ b/dockerfiles/r-ver_4.1.3.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.1.3
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_4.2.0.Dockerfile
+++ b/dockerfiles/r-ver_4.2.0.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=4.2.0
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/dockerfiles/r-ver_devel.Dockerfile
+++ b/dockerfiles/r-ver_devel.Dockerfile
@@ -6,7 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV R_VERSION=devel
-ENV TERM=xterm
 ENV R_HOME=/usr/local/lib/R
 ENV TZ=Etc/UTC
 

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -21,7 +21,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.0",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -12,7 +12,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.1",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -12,7 +12,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.2",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -12,7 +12,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.3",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -12,7 +12,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.4",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -12,7 +12,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.0.5",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.1.0",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -269,7 +268,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "4.1.0",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.1.1",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -269,7 +268,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "4.1.1",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.1.2",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -269,7 +268,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "4.1.2",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.1.3",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -284,7 +283,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "4.1.3",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:focal",
       "ENV": {
         "R_VERSION": "4.2.0",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -314,7 +313,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "4.2.0",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -26,7 +26,6 @@
       "FROM": "ubuntu:latest",
       "ENV": {
         "R_VERSION": "devel",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC"
       },
@@ -235,7 +234,6 @@
       "FROM": "nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04",
       "ENV": {
         "R_VERSION": "devel",
-        "TERM": "xterm",
         "R_HOME": "/usr/local/lib/R",
         "TZ": "Etc/UTC",
         "NVBLAS_CONFIG_FILE": "/etc/nvblas.conf",


### PR DESCRIPTION
Since it has already been set in the base images, there appears to be no need for setting in our Dockerfiles.

```shell
$ docker run --rm -it ubuntu bash
$ echo $TERM
xterm
```