### PR TITLE
[CI] Allow changing the base image for rocker_scripts tests, and some improvements

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: generate_matrix
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Prepare build
+        id: prep
+        run: |
+          test_name="${{ matrix.base_image }}-${{ matrix.tag }}-${{ matrix.script_name }}-${{ matrix.script_arg }}"
+          echo ::set-output name=output_tag::"${test_name/"/"/"-"}"
       - name: test build
         run: |
           docker buildx build . -f tests/rocker_scripts/Dockerfile \
@@ -43,4 +48,13 @@ jobs:
           --build-arg base_image=${{ matrix.base_image }} \
           --build-arg tag=${{ matrix.tag }} \
           --build-arg script_name=${{ matrix.script_name }} \
-          --build-arg script_arg=${{ matrix.script_arg }}
+          --build-arg script_arg=${{ matrix.script_arg }} \
+          --tag ${{ steps.prep.outputs.output_tag }}
+      - name: inspect image
+        run: |
+          make inspect-image/"${{ steps.prep.outputs.output_tag }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: tmp
+          path: tmp

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           docker buildx build . -f tests/rocker_scripts/Dockerfile \
           --output=type=docker \
+          --build-arg base_image=${{ matrix.base_image }} \
           --build-arg tag=${{ matrix.tag }} \
           --build-arg script_name=${{ matrix.script_name }} \
           --build-arg script_arg=${{ matrix.script_arg }}

--- a/tests/rocker_scripts/Dockerfile
+++ b/tests/rocker_scripts/Dockerfile
@@ -1,5 +1,6 @@
-ARG tag=latest
-FROM rocker/r-ver:${tag}
+ARG base_image="rocker/r-ver"
+ARG tag="latest"
+FROM ${base_image}:${tag}
 
 COPY tests/rocker_scripts/test.sh /test.sh
 COPY scripts /rocker_scripts

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -1,4 +1,7 @@
 {
+  "base_image": [
+    "rocker/r-ver"
+  ],
   "tag": [
     "4.0.0",
     "latest"
@@ -17,16 +20,19 @@
   ],
   "include": [
     {
+      "base_image": "rocker/r-ver",
       "tag": "4.0.0",
       "script_name": "install_rstudio.sh",
       "script_arg": "1.3.959"
     },
     {
+      "base_image": "rocker/r-ver",
       "tag": "latest",
       "script_name": "install_pandoc.sh",
       "script_arg": "2.18"
     },
     {
+      "base_image": "rocker/r-ver",
       "tag": "latest",
       "script_name": "install_quarto.sh",
       "script_arg": "0.9.260"


### PR DESCRIPTION
- Add new arg `base_image` to change the base image for a test build.
- Upload test build inspect files.
- `fail-fast: false` not to stop build by troubles.