### PR TITLE
Improve testing and refactoring of rocker scripts

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Prepare build
         id: prep
         run: |
-          test_name="${{ matrix.base_image }}-${{ matrix.tag }}-${{ matrix.script_name }}-${{ matrix.script_arg }}"
+          lower_script_name=$(echo ${{ matrix.script_name }} | tr '[:upper:]' '[:lower:]')
+          test_name="${{ matrix.base_image }}-${{ matrix.tag }}-${lower_script_name}-${{ matrix.script_arg }}"
           echo ::set-output name=output_tag::"${test_name/"/"/"-"}"
       - name: test build
         run: |

--- a/dockerfiles/binder_4.0.0.Dockerfile
+++ b/dockerfiles/binder_4.0.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.1.Dockerfile
+++ b/dockerfiles/binder_4.0.1.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.2.Dockerfile
+++ b/dockerfiles/binder_4.0.2.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.3.Dockerfile
+++ b/dockerfiles/binder_4.0.3.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.4.Dockerfile
+++ b/dockerfiles/binder_4.0.4.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.5.Dockerfile
+++ b/dockerfiles/binder_4.0.5.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.0.Dockerfile
+++ b/dockerfiles/binder_4.1.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.1.Dockerfile
+++ b/dockerfiles/binder_4.1.1.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.2.Dockerfile
+++ b/dockerfiles/binder_4.1.2.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.3.Dockerfile
+++ b/dockerfiles/binder_4.1.3.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.0.Dockerfile
+++ b/dockerfiles/binder_4.2.0.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_devel.Dockerfile
+++ b/dockerfiles/binder_devel.Dockerfile
@@ -7,12 +7,11 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV NB_USER=rstudio
 
-RUN /rocker_scripts/install_python.sh
 RUN /rocker_scripts/install_binder.sh
 
 EXPOSE 8888
 
-CMD jupyter notebook --ip 0.0.0.0
+CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0"]
 
 USER ${NB_USER}
 

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -27,5 +27,7 @@ if [ -x "$(command -v shiny-server)" ]; then
 fi
 
 ## configure git not to request password each time
-git config --system credential.helper 'cache --timeout=3600'
-git config --system push.default simple
+if [ -x "$(command -v git)" ]; then
+    git config --system credential.helper 'cache --timeout=3600'
+    git config --system push.default simple
+fi

--- a/scripts/install_binder.sh
+++ b/scripts/install_binder.sh
@@ -1,31 +1,56 @@
 #!/bin/bash
 set -e
 
-## force install of last working version of rstudio, if necessary
-# RSTUDIO_VERSION=1.3.959 /rocker_scripts/install_rstudio.sh
+## build ARGs
+NCPUS=${NCPUS:-"-1"}
 
-## NOTE: this runs as user NB_USER!
+NB_USER=${NB_USER:-${DEFAULT_USER:-"rstudio"}}
+
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
+    sudo \
+    libzmq3-dev
+
+# set up the default user if it does not exist
+if ! id -u "${NB_USER}" >/dev/null 2>&1; then
+    /rocker_scripts/default_user.sh "${NB_USER}"
+fi
+
+# install python
+/rocker_scripts/install_python.sh
+
 PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-/opt/venv/reticulate}
-DEFAULT_USER=${DEFAULT_USER:-rstudio}
-NB_USER=${NB_USER:-${DEFAULT_USER}}
-NB_UID=${NB_UID:-1000}
 WORKDIR=${WORKDIR:-/home/${NB_USER}}
-usermod -l "${NB_USER}" "${DEFAULT_USER}"
 # Create a venv dir owned by unprivileged user & set up notebook in it
 # This allows non-root to install python libraries if required
 mkdir -p "${PYTHON_VENV_PATH}"
 chown -R "${NB_USER}" "${PYTHON_VENV_PATH}"
 
+# to use pyenv in a RStudio session, we need to include the PATH in the .profile file
+# https://github.com/rocker-org/rocker-versioned2/issues/428
 PATH=/opt/pyenv/bin:${PATH}
-
-# And set ENV for R! It doesn't read from the environment...
-echo "PATH=${PATH}" >>"${R_HOME}/etc/Renviron.site"
 echo "export PATH=${PATH}" >>"${WORKDIR}/.profile"
 
 cd "${WORKDIR}"
 ## This gets run as user
 sudo -u "${NB_USER}" python3 -m venv "${PYTHON_VENV_PATH}"
-pip3 install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab >=2.0
 
-R --quiet -e "devtools::install_github('IRkernel/IRkernel')"
+python3 -m pip install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab
+
+install2.r --error --skipinstalled -n "$NCPUS" remotes
+
+R --quiet -e "remotes::install_github('IRkernel/IRkernel')"
 R --quiet -e "IRkernel::installspec(prefix='${PYTHON_VENV_PATH}')"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/downloaded_packages

--- a/scripts/install_cuda-10.1.sh
+++ b/scripts/install_cuda-10.1.sh
@@ -4,7 +4,8 @@ set -e
 apt-get update
 apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates
-curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add -
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" >/etc/apt/sources.list.d/cuda.list
 echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" >/etc/apt/sources.list.d/nvidia-ml.list
 apt-get purge --autoremove -y curl

--- a/scripts/install_cuda-10.1.sh
+++ b/scripts/install_cuda-10.1.sh
@@ -20,6 +20,7 @@ apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repo
 apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" >/etc/apt/sources.list.d/cuda.list
 echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" >/etc/apt/sources.list.d/nvidia-ml.list
+apt-get update
 
 CUDA_VERSION=${CUDA_VERSION:-10.1.243}
 CUDA_PKG_VERSION=${CUDA_PKG_VERSION:-10-1=$CUDA_VERSION-1}

--- a/scripts/install_cuda-11.1.sh
+++ b/scripts/install_cuda-11.1.sh
@@ -4,7 +4,8 @@ set -e
 apt-get update
 apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates
-curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub | apt-key add -
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/cuda.list
 echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/nvidia-ml.list
 apt-get purge --autoremove -y curl

--- a/scripts/install_cuda-11.1.sh
+++ b/scripts/install_cuda-11.1.sh
@@ -20,6 +20,7 @@ apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repo
 apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/cuda.list
 echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/nvidia-ml.list
+apt-get update
 
 CUDA_VERSION=${CUDA_VERSION:-11.1.1}
 

--- a/scripts/install_cuda-11.1.sh
+++ b/scripts/install_cuda-11.1.sh
@@ -1,25 +1,34 @@
 #!/bin/bash
 set -e
 
-apt-get update
-apt-get install -y --no-install-recommends \
-    gnupg2 curl ca-certificates
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
+    gnupg2 \
+    curl \
+    ca-certificates
+
 apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
 apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/cuda.list
 echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" >/etc/apt/sources.list.d/nvidia-ml.list
-apt-get purge --autoremove -y curl
-rm -rf /var/lib/apt/lists/*
 
 CUDA_VERSION=${CUDA_VERSION:-11.1.1}
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
-apt-get update
-apt-get install -y --no-install-recommends \
+apt_install \
     cuda-cudart-11-1=11.1.74-1 \
     cuda-compat-11-1
+
 ln -s cuda-11.1 /usr/local/cuda
-rm -rf /var/lib/apt/lists/*
 
 # Required for nvidia-docker v1
 echo "/usr/local/nvidia/lib" >>/etc/ld.so.conf.d/nvidia.conf
@@ -38,20 +47,18 @@ echo "/usr/local/nvidia/lib64" >>/etc/ld.so.conf.d/nvidia.conf
 
 NCCL_VERSION=${NCCL_VERSION:-2.7.8}
 
-apt-get update
-apt-get install -y --no-install-recommends \
+apt_install \
     cuda-libraries-11-1=11.1.1-1 \
     libnpp-11-1=11.1.2.301-1 \
     cuda-nvtx-11-1=11.1.74-1 \
     libcublas-11-1=11.3.0.106-1 \
     "libnccl2=$NCCL_VERSION-1+cuda11.1"
+
 apt-mark hold libnccl2
-rm -rf /var/lib/apt/lists/*
 
 ## devel #######################################################
 
-apt-get update
-apt-get install -y --no-install-recommends \
+apt_install \
     cuda-nvml-dev-11-1=11.1.74-1 \
     cuda-command-line-tools-11-1=11.1.1-1 \
     cuda-nvprof-11-1=11.1.105-1 \
@@ -63,4 +70,6 @@ apt-get install -y --no-install-recommends \
     libcusparse-11-1=11.3.0.10-1 \
     libcusparse-dev-11-1=11.3.0.10-1
 apt-mark hold libnccl-dev
+
+# Clean up
 rm -rf /var/lib/apt/lists/*

--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -7,8 +7,17 @@ export DEBIAN_FRONTEND=noninteractive
 ## build ARGs
 NCPUS=${NCPUS:--1}
 
-apt-get update
-apt-get install -y --no-install-recommends \
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
     gdal-bin \
     lbzip2 \
     libfftw3-dev \

--- a/scripts/install_julia.sh
+++ b/scripts/install_julia.sh
@@ -6,6 +6,16 @@ NCPUS=${NCPUS:--1}
 
 JULIA_VERSION=${1:-${JULIA_VERSION:-latest}}
 
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
 ARCH_LONG=$(uname -p)
 ARCH_SHORT=$ARCH_LONG
 
@@ -13,10 +23,7 @@ if [ "$ARCH_LONG" = "x86_64" ]; then
     ARCH_SHORT="x64"
 fi
 
-if [ ! -x "$(command -v wget)" ]; then
-    apt-get update
-    apt-get -y install wget
-fi
+apt_install wget
 
 install2.r --error --skipinstalled -n "$NCPUS" \
     yaml \

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -13,10 +13,17 @@ set -e
 PANDOC_VERSION=${1:-${PANDOC_VERSION:-"default"}}
 ARCH=$(dpkg --print-architecture)
 
-if [ ! -x "$(command -v wget)" ]; then
-    apt-get update
-    apt-get -y install wget
-fi
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install wget
 
 if [ -x "$(command -v pandoc)" ]; then
     INSTALLED_PANDOC_VERSION=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')

--- a/scripts/install_pyenv.sh
+++ b/scripts/install_pyenv.sh
@@ -9,12 +9,23 @@
 set -e
 
 PYTHON_CONFIGURE_OPTS=${PYTHON_CONFIGURE_OPTS:-"--enable-shared"}
+
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
 echo "PYTHON_CONFIGURE_OPTS=${PYTHON_CONFIGURE_OPTS}" >>"${R_HOME}/etc/R_environ"
 
-if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-    apt-get update
-fi
-apt-get -y install curl python3-pip
+apt_install \
+    curl \
+    python3-pip
+
 python3 -m pip --no-cache-dir install --upgrade --ignore-installed pipenv
 
 # consider a version-stable alternative for the installer?

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -8,8 +8,17 @@ WORKON_HOME=${WORKON_HOME:-/opt/venv}
 PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-${WORKON_HOME}/reticulate}
 RETICULATE_MINICONDA_ENABLED=${RETICULATE_MINICONDA_ENABLED:-FALSE}
 
-apt-get update
-apt-get install -y --no-install-recommends \
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
     git \
     libpng-dev \
     libpython3-dev \
@@ -17,8 +26,7 @@ apt-get install -y --no-install-recommends \
     python3-pip \
     python3-virtualenv \
     python3-venv \
-    swig &&
-    rm -rf /var/lib/apt/lists/*
+    swig
 
 python3 -m pip --no-cache-dir install --upgrade \
     pip \

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -17,10 +17,17 @@ QUARTO_VERSION=${1:-${QUARTO_VERSION:-"latest"}}
 # Only amd64 build can be installed now
 ARCH=$(dpkg --print-architecture)
 
-if [ ! -x "$(command -v wget)" ]; then
-    apt-get update
-    apt-get -y install wget
-fi
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install wget
 
 if [ -x "$(command -v quarto)" ]; then
     INSTALLED_QUARTO_VERSION=$(quarto --version)

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -5,6 +5,16 @@ set -e
 
 S6_VERSION=${1:-${S6_VERSION:-"v2.1.0.2"}}
 
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
 ARCH=$(dpkg --print-architecture)
 
 if [ "$ARCH" = "arm64" ]; then
@@ -13,10 +23,7 @@ fi
 
 DOWNLOAD_FILE=s6-overlay-${ARCH}.tar.gz
 
-if [ ! -x "$(command -v wget)" ]; then
-    apt-get update
-    apt-get -y install wget
-fi
+apt_install wget
 
 ## Set up S6 init system
 if [ -f "/rocker_scripts/.s6_version" ] && [ "$S6_VERSION" = "$(cat /rocker_scripts/.s6_version)" ]; then

--- a/scripts/install_tf1_cuda_10_0.sh
+++ b/scripts/install_tf1_cuda_10_0.sh
@@ -7,10 +7,23 @@ set -e
 
 # Fortunately, these are available from the NVIDIA Ubuntu debian PPA repos added in 10.1 images
 
-apt-get update && apt-get install -y \
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
     cuda-cudart-10-0 \
     cuda-cufft-10-0 \
     cuda-cusolver-10-0 \
     cuda-curand-10-0 \
     cuda-cusparse-10-0 \
     cuda-cublas-10-0
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -5,8 +5,17 @@ set -e
 ## build ARGs
 NCPUS=${NCPUS:--1}
 
-apt-get update
-apt-get -y --no-install-recommends install \
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install \
     libxml2-dev \
     libcairo2-dev \
     libgit2-dev \
@@ -18,7 +27,6 @@ apt-get -y --no-install-recommends install \
     libxtst6 \
     libcurl4-openssl-dev \
     unixodbc-dev
-rm -rf /var/lib/apt/lists/*
 
 install2.r --error --skipinstalled -n "$NCPUS" \
     tidyverse \
@@ -45,6 +53,8 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
 ## a bridge to far? -- brings in another 60 packages
 # install2.r --error --skipinstalled -n "$NCPUS" tidymodels
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/downloaded_packages
 
 # Check the tidyverse core packages' version

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -3,10 +3,17 @@ set -e
 
 ## https://www.cpc.ncep.noaa.gov/products/wesley/wgrib2/
 
-if [ ! -x "$(command -v wget)" ]; then
-    apt-get update
-    apt-get -y install wget
-fi
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install wget
 
 cd /opt
 wget https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -150,12 +150,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.0"

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.1"

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.2"

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.3"

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -141,12 +141,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.4"

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -148,12 +148,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.5",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.0"

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.1"

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -163,12 +163,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.2"

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -170,12 +170,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.3",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -184,12 +184,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.0",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -132,12 +132,11 @@
         "NB_USER": "rstudio"
       },
       "RUN": [
-        "/rocker_scripts/install_python.sh",
         "/rocker_scripts/install_binder.sh"
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "jupyter notebook --ip 0.0.0.0",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0\"]",
       "EXPOSE": 8888
     },
     {

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -13,7 +13,8 @@
     "install_verse.sh",
     "install_quarto.sh",
     "install_shiny_server.sh",
-    "install_geospatial.sh"
+    "install_geospatial.sh",
+    "install_cuda-10.1.sh"
   ],
   "script_arg": [
     "none"
@@ -42,6 +43,12 @@
       "tag": "latest",
       "script_name": "install_quarto.sh",
       "script_arg": "0.9.260"
+    },
+    {
+      "base_image": "rocker/r-ver",
+      "tag": "4.0.5",
+      "script_name": "install_cuda-11.1.sh",
+      "script_arg": "none"
     }
   ]
 }

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -27,6 +27,12 @@
     },
     {
       "base_image": "rocker/r-ver",
+      "tag": "devel",
+      "script_name": "install_rstudio.sh",
+      "script_arg": "daily"
+    },
+    {
+      "base_image": "rocker/r-ver",
       "tag": "latest",
       "script_name": "install_pandoc.sh",
       "script_arg": "2.18"

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -52,6 +52,12 @@
       "tag": "4.0.5",
       "script_name": "install_cuda-11.1.sh",
       "script_arg": "none"
+    },
+    {
+      "base_image": "rocker/cuda",
+      "tag": "cuda11.1",
+      "script_name": "config_R_cuda.sh",
+      "script_arg": "none"
     }
   ]
 }

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -14,6 +14,9 @@
     "install_quarto.sh",
     "install_shiny_server.sh",
     "install_geospatial.sh",
+    "install_python.sh",
+    "install_binder.sh",
+    "install_julia.sh",
     "install_cuda-10.1.sh"
   ],
   "script_arg": [


### PR DESCRIPTION
Add test cases and refactor each script.

- Add tests for the following scripts.
  With this change, all scripts used in pre-built images (except extra images) will be tested.
  - `install_cuda-10.1.sh`
  - `install_cuda-11.1.sh`
  - `config_R_cuda.sh`
 - Refactor each script
  (mainly removing unnecessary `apt update`, which can affect run time, especially in places far from the United States)

This PR includes the following PR tasks
(Originally, I think it is better to separate Pull Requests for each modification, but to avoid conflicts in the test definition file, I have put them together in one PR.)

- Update `install_rstudio.sh` for suporting `ubuntu:jammy` (#435)
- Update `install_binder.sh` to be able to run alone (#438)

And some other fixes.

- Add new GPG key for installing cuda packages. (fix #442)