### PR TITLE
[CI] Push images to GitHub Container registry too

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -50,10 +50,17 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -26,10 +26,17 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/bakefiles/4.1.3.docker-bake.json
+++ b/bakefiles/4.1.3.docker-bake.json
@@ -41,7 +41,9 @@
       },
       "tags": [
         "docker.io/rocker/r-ver:4.1.3",
-        "docker.io/rocker/r-ver:4.1"
+        "ghcr.io/rocker-org/r-ver:4.1.3",
+        "docker.io/rocker/r-ver:4.1",
+        "ghcr.io/rocker-org/r-ver:4.1"
       ],
       "platforms": [
         "linux/amd64",
@@ -65,7 +67,9 @@
       },
       "tags": [
         "docker.io/rocker/rstudio:4.1.3",
-        "docker.io/rocker/rstudio:4.1"
+        "ghcr.io/rocker-org/rstudio:4.1.3",
+        "docker.io/rocker/rstudio:4.1",
+        "ghcr.io/rocker-org/rstudio:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -88,7 +92,9 @@
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.1.3",
-        "docker.io/rocker/tidyverse:4.1"
+        "ghcr.io/rocker-org/tidyverse:4.1.3",
+        "docker.io/rocker/tidyverse:4.1",
+        "ghcr.io/rocker-org/tidyverse:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -111,7 +117,9 @@
       },
       "tags": [
         "docker.io/rocker/verse:4.1.3",
-        "docker.io/rocker/verse:4.1"
+        "ghcr.io/rocker-org/verse:4.1.3",
+        "docker.io/rocker/verse:4.1",
+        "ghcr.io/rocker-org/verse:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -134,7 +142,9 @@
       },
       "tags": [
         "docker.io/rocker/geospatial:4.1.3",
-        "docker.io/rocker/geospatial:4.1"
+        "ghcr.io/rocker-org/geospatial:4.1.3",
+        "docker.io/rocker/geospatial:4.1",
+        "ghcr.io/rocker-org/geospatial:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -157,7 +167,9 @@
       },
       "tags": [
         "docker.io/rocker/shiny:4.1.3",
-        "docker.io/rocker/shiny:4.1"
+        "ghcr.io/rocker-org/shiny:4.1.3",
+        "docker.io/rocker/shiny:4.1",
+        "ghcr.io/rocker-org/shiny:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -180,7 +192,9 @@
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.1.3",
-        "docker.io/rocker/shiny-verse:4.1"
+        "ghcr.io/rocker-org/shiny-verse:4.1.3",
+        "docker.io/rocker/shiny-verse:4.1",
+        "ghcr.io/rocker-org/shiny-verse:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -203,7 +217,9 @@
       },
       "tags": [
         "docker.io/rocker/binder:4.1.3",
-        "docker.io/rocker/binder:4.1"
+        "ghcr.io/rocker-org/binder:4.1.3",
+        "docker.io/rocker/binder:4.1",
+        "ghcr.io/rocker-org/binder:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -226,9 +242,13 @@
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.3-cuda10.1",
-        "docker.io/rocker/cuda:4.1-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.1.3-cuda10.1",
         "docker.io/rocker/cuda:4.1.3",
+        "ghcr.io/rocker-org/cuda:4.1.3",
+        "docker.io/rocker/cuda:4.1-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.1-cuda10.1",
         "docker.io/rocker/cuda:4.1",
+        "ghcr.io/rocker-org/cuda:4.1",
         "docker.io/rocker/r-ver:4.1.3-cuda10.1"
       ],
       "platforms": [
@@ -252,9 +272,13 @@
       },
       "tags": [
         "docker.io/rocker/ml:4.1.3-cuda10.1",
-        "docker.io/rocker/ml:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.1.3-cuda10.1",
         "docker.io/rocker/ml:4.1.3",
-        "docker.io/rocker/ml:4.1"
+        "ghcr.io/rocker-org/ml:4.1.3",
+        "docker.io/rocker/ml:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.1-cuda10.1",
+        "docker.io/rocker/ml:4.1",
+        "ghcr.io/rocker-org/ml:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -277,9 +301,13 @@
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.3-cuda10.1",
-        "docker.io/rocker/ml-verse:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.1.3-cuda10.1",
         "docker.io/rocker/ml-verse:4.1.3",
-        "docker.io/rocker/ml-verse:4.1"
+        "ghcr.io/rocker-org/ml-verse:4.1.3",
+        "docker.io/rocker/ml-verse:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.1-cuda10.1",
+        "docker.io/rocker/ml-verse:4.1",
+        "ghcr.io/rocker-org/ml-verse:4.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -302,7 +330,9 @@
       },
       "tags": [
         "docker.io/rocker/cuda:4.1.3-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.1.3-cuda11.1",
         "docker.io/rocker/cuda:4.1-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.1-cuda11.1",
         "docker.io/rocker/r-ver:4.1.3-cuda11.1"
       ],
       "platforms": [
@@ -326,7 +356,9 @@
       },
       "tags": [
         "docker.io/rocker/ml:4.1.3-cuda11.1",
-        "docker.io/rocker/ml:4.1-cuda11.1"
+        "ghcr.io/rocker-org/ml:4.1.3-cuda11.1",
+        "docker.io/rocker/ml:4.1-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.1-cuda11.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -349,7 +381,9 @@
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.1.3-cuda11.1",
-        "docker.io/rocker/ml-verse:4.1-cuda11.1"
+        "ghcr.io/rocker-org/ml-verse:4.1.3-cuda11.1",
+        "docker.io/rocker/ml-verse:4.1-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.1-cuda11.1"
       ],
       "platforms": [
         "linux/amd64"

--- a/bakefiles/4.2.0.docker-bake.json
+++ b/bakefiles/4.2.0.docker-bake.json
@@ -41,9 +41,13 @@
       },
       "tags": [
         "docker.io/rocker/r-ver:4.2.0",
+        "ghcr.io/rocker-org/r-ver:4.2.0",
         "docker.io/rocker/r-ver:4.2",
+        "ghcr.io/rocker-org/r-ver:4.2",
         "docker.io/rocker/r-ver:4",
-        "docker.io/rocker/r-ver:latest"
+        "ghcr.io/rocker-org/r-ver:4",
+        "docker.io/rocker/r-ver:latest",
+        "ghcr.io/rocker-org/r-ver:latest"
       ],
       "platforms": [
         "linux/amd64",
@@ -67,9 +71,13 @@
       },
       "tags": [
         "docker.io/rocker/rstudio:4.2.0",
+        "ghcr.io/rocker-org/rstudio:4.2.0",
         "docker.io/rocker/rstudio:4.2",
+        "ghcr.io/rocker-org/rstudio:4.2",
         "docker.io/rocker/rstudio:4",
-        "docker.io/rocker/rstudio:latest"
+        "ghcr.io/rocker-org/rstudio:4",
+        "docker.io/rocker/rstudio:latest",
+        "ghcr.io/rocker-org/rstudio:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -92,9 +100,13 @@
       },
       "tags": [
         "docker.io/rocker/tidyverse:4.2.0",
+        "ghcr.io/rocker-org/tidyverse:4.2.0",
         "docker.io/rocker/tidyverse:4.2",
+        "ghcr.io/rocker-org/tidyverse:4.2",
         "docker.io/rocker/tidyverse:4",
-        "docker.io/rocker/tidyverse:latest"
+        "ghcr.io/rocker-org/tidyverse:4",
+        "docker.io/rocker/tidyverse:latest",
+        "ghcr.io/rocker-org/tidyverse:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -117,9 +129,13 @@
       },
       "tags": [
         "docker.io/rocker/verse:4.2.0",
+        "ghcr.io/rocker-org/verse:4.2.0",
         "docker.io/rocker/verse:4.2",
+        "ghcr.io/rocker-org/verse:4.2",
         "docker.io/rocker/verse:4",
-        "docker.io/rocker/verse:latest"
+        "ghcr.io/rocker-org/verse:4",
+        "docker.io/rocker/verse:latest",
+        "ghcr.io/rocker-org/verse:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -142,9 +158,13 @@
       },
       "tags": [
         "docker.io/rocker/geospatial:4.2.0",
+        "ghcr.io/rocker-org/geospatial:4.2.0",
         "docker.io/rocker/geospatial:4.2",
+        "ghcr.io/rocker-org/geospatial:4.2",
         "docker.io/rocker/geospatial:4",
-        "docker.io/rocker/geospatial:latest"
+        "ghcr.io/rocker-org/geospatial:4",
+        "docker.io/rocker/geospatial:latest",
+        "ghcr.io/rocker-org/geospatial:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -167,9 +187,13 @@
       },
       "tags": [
         "docker.io/rocker/shiny:4.2.0",
+        "ghcr.io/rocker-org/shiny:4.2.0",
         "docker.io/rocker/shiny:4.2",
+        "ghcr.io/rocker-org/shiny:4.2",
         "docker.io/rocker/shiny:4",
-        "docker.io/rocker/shiny:latest"
+        "ghcr.io/rocker-org/shiny:4",
+        "docker.io/rocker/shiny:latest",
+        "ghcr.io/rocker-org/shiny:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -192,9 +216,13 @@
       },
       "tags": [
         "docker.io/rocker/shiny-verse:4.2.0",
+        "ghcr.io/rocker-org/shiny-verse:4.2.0",
         "docker.io/rocker/shiny-verse:4.2",
+        "ghcr.io/rocker-org/shiny-verse:4.2",
         "docker.io/rocker/shiny-verse:4",
-        "docker.io/rocker/shiny-verse:latest"
+        "ghcr.io/rocker-org/shiny-verse:4",
+        "docker.io/rocker/shiny-verse:latest",
+        "ghcr.io/rocker-org/shiny-verse:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -217,9 +245,13 @@
       },
       "tags": [
         "docker.io/rocker/binder:4.2.0",
+        "ghcr.io/rocker-org/binder:4.2.0",
         "docker.io/rocker/binder:4.2",
+        "ghcr.io/rocker-org/binder:4.2",
         "docker.io/rocker/binder:4",
-        "docker.io/rocker/binder:latest"
+        "ghcr.io/rocker-org/binder:4",
+        "docker.io/rocker/binder:latest",
+        "ghcr.io/rocker-org/binder:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -242,13 +274,21 @@
       },
       "tags": [
         "docker.io/rocker/cuda:4.2.0-cuda10.1",
-        "docker.io/rocker/cuda:4.2-cuda10.1",
-        "docker.io/rocker/cuda:4-cuda10.1",
-        "docker.io/rocker/cuda:cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.2.0-cuda10.1",
         "docker.io/rocker/cuda:4.2.0",
+        "ghcr.io/rocker-org/cuda:4.2.0",
+        "docker.io/rocker/cuda:4.2-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.2-cuda10.1",
         "docker.io/rocker/cuda:4.2",
+        "ghcr.io/rocker-org/cuda:4.2",
+        "docker.io/rocker/cuda:4-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4-cuda10.1",
         "docker.io/rocker/cuda:4",
+        "ghcr.io/rocker-org/cuda:4",
+        "docker.io/rocker/cuda:cuda10.1",
+        "ghcr.io/rocker-org/cuda:cuda10.1",
         "docker.io/rocker/cuda:latest",
+        "ghcr.io/rocker-org/cuda:latest",
         "docker.io/rocker/r-ver:4.2.0-cuda10.1"
       ],
       "platforms": [
@@ -272,13 +312,21 @@
       },
       "tags": [
         "docker.io/rocker/ml:4.2.0-cuda10.1",
-        "docker.io/rocker/ml:4.2-cuda10.1",
-        "docker.io/rocker/ml:4-cuda10.1",
-        "docker.io/rocker/ml:cuda10.1",
+        "ghcr.io/rocker-org/ml:4.2.0-cuda10.1",
         "docker.io/rocker/ml:4.2.0",
+        "ghcr.io/rocker-org/ml:4.2.0",
+        "docker.io/rocker/ml:4.2-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.2-cuda10.1",
         "docker.io/rocker/ml:4.2",
+        "ghcr.io/rocker-org/ml:4.2",
+        "docker.io/rocker/ml:4-cuda10.1",
+        "ghcr.io/rocker-org/ml:4-cuda10.1",
         "docker.io/rocker/ml:4",
-        "docker.io/rocker/ml:latest"
+        "ghcr.io/rocker-org/ml:4",
+        "docker.io/rocker/ml:cuda10.1",
+        "ghcr.io/rocker-org/ml:cuda10.1",
+        "docker.io/rocker/ml:latest",
+        "ghcr.io/rocker-org/ml:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -301,13 +349,21 @@
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.2.0-cuda10.1",
-        "docker.io/rocker/ml-verse:4.2-cuda10.1",
-        "docker.io/rocker/ml-verse:4-cuda10.1",
-        "docker.io/rocker/ml-verse:cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.2.0-cuda10.1",
         "docker.io/rocker/ml-verse:4.2.0",
+        "ghcr.io/rocker-org/ml-verse:4.2.0",
+        "docker.io/rocker/ml-verse:4.2-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.2-cuda10.1",
         "docker.io/rocker/ml-verse:4.2",
+        "ghcr.io/rocker-org/ml-verse:4.2",
+        "docker.io/rocker/ml-verse:4-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4-cuda10.1",
         "docker.io/rocker/ml-verse:4",
-        "docker.io/rocker/ml-verse:latest"
+        "ghcr.io/rocker-org/ml-verse:4",
+        "docker.io/rocker/ml-verse:cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:cuda10.1",
+        "docker.io/rocker/ml-verse:latest",
+        "ghcr.io/rocker-org/ml-verse:latest"
       ],
       "platforms": [
         "linux/amd64"
@@ -330,9 +386,13 @@
       },
       "tags": [
         "docker.io/rocker/cuda:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.2.0-cuda11.1",
         "docker.io/rocker/cuda:4.2-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.2-cuda11.1",
         "docker.io/rocker/cuda:4-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4-cuda11.1",
         "docker.io/rocker/cuda:cuda11.1",
+        "ghcr.io/rocker-org/cuda:cuda11.1",
         "docker.io/rocker/r-ver:4.2.0-cuda11.1"
       ],
       "platforms": [
@@ -356,9 +416,13 @@
       },
       "tags": [
         "docker.io/rocker/ml:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.2.0-cuda11.1",
         "docker.io/rocker/ml:4.2-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.2-cuda11.1",
         "docker.io/rocker/ml:4-cuda11.1",
-        "docker.io/rocker/ml:cuda11.1"
+        "ghcr.io/rocker-org/ml:4-cuda11.1",
+        "docker.io/rocker/ml:cuda11.1",
+        "ghcr.io/rocker-org/ml:cuda11.1"
       ],
       "platforms": [
         "linux/amd64"
@@ -381,9 +445,13 @@
       },
       "tags": [
         "docker.io/rocker/ml-verse:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.2.0-cuda11.1",
         "docker.io/rocker/ml-verse:4.2-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.2-cuda11.1",
         "docker.io/rocker/ml-verse:4-cuda11.1",
-        "docker.io/rocker/ml-verse:cuda11.1"
+        "ghcr.io/rocker-org/ml-verse:4-cuda11.1",
+        "docker.io/rocker/ml-verse:cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:cuda11.1"
       ],
       "platforms": [
         "linux/amd64"

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -37,7 +37,9 @@
       },
       "tags": [
         "docker.io/rocker/geospatial:4.2.0-ubuntugis",
-        "docker.io/rocker/geospatial:ubuntugis"
+        "ghcr.io/rocker-org/geospatial:4.2.0-ubuntugis",
+        "docker.io/rocker/geospatial:ubuntugis",
+        "ghcr.io/rocker-org/geospatial:ubuntugis"
       ],
       "platforms": [
         "linux/amd64"
@@ -59,7 +61,8 @@
         "org.opencontainers.image.version": "R-4.2.0"
       },
       "tags": [
-        "docker.io/rocker/geospatial:dev-osgeo"
+        "docker.io/rocker/geospatial:dev-osgeo",
+        "ghcr.io/rocker-org/geospatial:dev-osgeo"
       ],
       "platforms": [
         "linux/amd64"

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -299,15 +299,8 @@ write_stack <- function(r_version,
       r_major_latest,
       r_latest,
       use_latest_tag = TRUE,
-      latest_tag = "cuda10.1",
-      tag_suffix = "-cuda10.1"
-    ),
-    .generate_tags(
-      c("docker.io/rocker/cuda", "ghcr.io/rocker-org/cuda"),
-      r_version,
-      r_minor_latest,
-      r_major_latest,
-      r_latest
+      latest_tag = c("cuda10.1", "latest"),
+      tag_suffix = c("-cuda10.1", "")
     ),
     list(stringr::str_c("docker.io/rocker/r-ver:", r_version, "-cuda10.1"))
   )
@@ -322,15 +315,8 @@ write_stack <- function(r_version,
       r_major_latest,
       r_latest,
       use_latest_tag = TRUE,
-      latest_tag = "cuda10.1",
-      tag_suffix = "-cuda10.1"
-    ),
-    .generate_tags(
-      c("docker.io/rocker/ml", "ghcr.io/rocker-org/ml"),
-      r_version,
-      r_minor_latest,
-      r_major_latest,
-      r_latest
+      latest_tag = c("cuda10.1", "latest"),
+      tag_suffix = c("-cuda10.1", "")
     )
   )
   template$stack[[10]]$ENV$RSTUDIO_VERSION <- rstudio_version
@@ -345,15 +331,8 @@ write_stack <- function(r_version,
       r_major_latest,
       r_latest,
       use_latest_tag = TRUE,
-      latest_tag = "cuda10.1",
-      tag_suffix = "-cuda10.1"
-    ),
-    .generate_tags(
-      c("docker.io/rocker/ml-verse", "ghcr.io/rocker-org/ml-verse"),
-      r_version,
-      r_minor_latest,
-      r_major_latest,
-      r_latest
+      latest_tag = c("cuda10.1", "latest"),
+      tag_suffix = c("-cuda10.1", "")
     )
   )
   template$stack[[11]]$ENV$CTAN_REPO <- ctan_url

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -197,7 +197,7 @@ write_stack <- function(r_version,
   # rocker/r-ver
   template$stack[[1]]$FROM <- stringr::str_c("ubuntu:", ubuntu_series)
   template$stack[[1]]$tags <- .generate_tags(
-    "docker.io/rocker/r-ver",
+    c("docker.io/rocker/r-ver", "ghcr.io/rocker-org/r-ver"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -212,7 +212,7 @@ write_stack <- function(r_version,
   # rocker/rstudio
   template$stack[[2]]$FROM <- stringr::str_c("rocker/r-ver:", r_version)
   template$stack[[2]]$tags <- .generate_tags(
-    "docker.io/rocker/rstudio",
+    c("docker.io/rocker/rstudio", "ghcr.io/rocker-org/rstudio"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -223,7 +223,7 @@ write_stack <- function(r_version,
   # rocker/tidyverse
   template$stack[[3]]$FROM <- stringr::str_c("rocker/rstudio:", r_version)
   template$stack[[3]]$tags <- .generate_tags(
-    "docker.io/rocker/tidyverse",
+    c("docker.io/rocker/tidyverse", "ghcr.io/rocker-org/tidyverse"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -233,7 +233,7 @@ write_stack <- function(r_version,
   # rocker/verse
   template$stack[[4]]$FROM <- stringr::str_c("rocker/tidyverse:", r_version)
   template$stack[[4]]$tags <- .generate_tags(
-    "docker.io/rocker/verse",
+    c("docker.io/rocker/verse", "ghcr.io/rocker-org/verse"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -244,7 +244,7 @@ write_stack <- function(r_version,
   # rocker/geospatial
   template$stack[[5]]$FROM <- stringr::str_c("rocker/verse:", r_version)
   template$stack[[5]]$tags <- .generate_tags(
-    "docker.io/rocker/geospatial",
+    c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -254,7 +254,7 @@ write_stack <- function(r_version,
   # rocker/shiny
   template$stack[[6]]$FROM <- stringr::str_c("rocker/r-ver:", r_version)
   template$stack[[6]]$tags <- .generate_tags(
-    "docker.io/rocker/shiny",
+    c("docker.io/rocker/shiny", "ghcr.io/rocker-org/shiny"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -264,7 +264,7 @@ write_stack <- function(r_version,
   # rocker/shiny-verse
   template$stack[[7]]$FROM <- stringr::str_c("rocker/shiny:", r_version)
   template$stack[[7]]$tags <- .generate_tags(
-    "docker.io/rocker/shiny-verse",
+    c("docker.io/rocker/shiny-verse", "ghcr.io/rocker-org/shiny-verse"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -274,7 +274,7 @@ write_stack <- function(r_version,
   # rocker/binder
   template$stack[[8]]$FROM <- stringr::str_c("rocker/geospatial:", r_version)
   template$stack[[8]]$tags <- .generate_tags(
-    "docker.io/rocker/binder",
+    c("docker.io/rocker/binder", "ghcr.io/rocker-org/binder"),
     r_version,
     r_minor_latest,
     r_major_latest,
@@ -285,7 +285,7 @@ write_stack <- function(r_version,
   template$stack[[9]]$FROM <- stringr::str_c("rocker/r-ver:", r_version)
   template$stack[[9]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/cuda",
+      c("docker.io/rocker/cuda", "ghcr.io/rocker-org/cuda"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -295,7 +295,7 @@ write_stack <- function(r_version,
       tag_suffix = "-cuda10.1"
     ),
     .generate_tags(
-      "docker.io/rocker/cuda",
+      c("docker.io/rocker/cuda", "ghcr.io/rocker-org/cuda"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -308,7 +308,7 @@ write_stack <- function(r_version,
   template$stack[[10]]$FROM <- stringr::str_c("rocker/cuda:", r_version)
   template$stack[[10]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/ml",
+      c("docker.io/rocker/ml", "ghcr.io/rocker-org/ml"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -318,7 +318,7 @@ write_stack <- function(r_version,
       tag_suffix = "-cuda10.1"
     ),
     .generate_tags(
-      "docker.io/rocker/ml",
+      c("docker.io/rocker/ml", "ghcr.io/rocker-org/ml"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -331,7 +331,7 @@ write_stack <- function(r_version,
   template$stack[[11]]$FROM <- stringr::str_c("rocker/ml:", r_version)
   template$stack[[11]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/ml-verse",
+      c("docker.io/rocker/ml-verse", "ghcr.io/rocker-org/ml-verse"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -341,7 +341,7 @@ write_stack <- function(r_version,
       tag_suffix = "-cuda10.1"
     ),
     .generate_tags(
-      "docker.io/rocker/ml-verse",
+      c("docker.io/rocker/ml-verse", "ghcr.io/rocker-org/ml-verse"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -354,7 +354,7 @@ write_stack <- function(r_version,
   template$stack[[12]]$FROM <- .cuda_baseimage_tag(ubuntu_series)
   template$stack[[12]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/cuda",
+      c("docker.io/rocker/cuda", "ghcr.io/rocker-org/cuda"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -374,7 +374,7 @@ write_stack <- function(r_version,
   template$stack[[13]]$FROM <- stringr::str_c("rocker/cuda:", r_version, "-cuda11.1")
   template$stack[[13]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/ml",
+      c("docker.io/rocker/ml", "ghcr.io/rocker-org/ml"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -390,7 +390,7 @@ write_stack <- function(r_version,
   template$stack[[14]]$FROM <- stringr::str_c("rocker/ml:", r_version, "-cuda11.1")
   template$stack[[14]]$tags <- c(
     .generate_tags(
-      "docker.io/rocker/ml-verse",
+      c("docker.io/rocker/ml-verse", "ghcr.io/rocker-org/ml-verse"),
       r_version,
       r_minor_latest,
       r_major_latest,
@@ -537,7 +537,7 @@ extra$TAG <- r_latest_version
 extra$stack[[1]]$FROM <- stringr::str_c("rocker/verse:", r_latest_version)
 extra$stack[[1]]$tags <- c(
   .generate_tags(
-    "docker.io/rocker/geospatial",
+    c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"),
     r_latest_version,
     r_minor_latest = FALSE,
     r_major_latest = FALSE,

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -523,20 +523,21 @@ extra <- jsonlite::read_json("stacks/extra.json")
 extra$TAG <- r_latest_version
 ## geospatial-ubuntugis
 extra$stack[[1]]$FROM <- stringr::str_c("rocker/verse:", r_latest_version)
-extra$stack[[1]]$tags <- c(
-  .generate_tags(
-    c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"),
-    r_latest_version,
-    r_minor_latest = FALSE,
-    r_major_latest = FALSE,
-    r_latest = TRUE,
-    use_latest_tag = TRUE,
-    latest_tag = "ubuntugis",
-    tag_suffix = "-ubuntugis"
-  )
+extra$stack[[1]]$tags <- .generate_tags(
+  c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"),
+  r_latest_version,
+  r_minor_latest = FALSE,
+  r_major_latest = FALSE,
+  r_latest = TRUE,
+  use_latest_tag = TRUE,
+  latest_tag = "ubuntugis",
+  tag_suffix = "-ubuntugis"
 )
 ## geospatial-dev-osgeo
 extra$stack[[2]]$FROM <- stringr::str_c("rocker/verse:", r_latest_version)
+extra$stack[[2]]$tags <- .outer_paste(
+  list(c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"), ":dev-osgeo")
+)
 extra$stack[[2]]$ENV$PROJ_VERSION <- .latest_version_of_git_repo("https://github.com/OSGeo/PROJ.git")
 extra$stack[[2]]$ENV$GDAL_VERSION <- .latest_version_of_git_repo("https://github.com/OSGeo/gdal.git")
 extra$stack[[2]]$ENV$GEOS_VERSION <- .latest_version_of_git_repo("https://github.com/libgeos/geos.git")

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -151,7 +151,7 @@ library(gert)
   if (r_major_latest == TRUE) {
     .tags <- c(.tags, stringr::str_c(base_name, ":", r_major_version, tag_suffix))
   }
-  if (r_latest == TRUE & use_latest_tag == TRUE) {
+  if (r_latest == TRUE && use_latest_tag == TRUE) {
     .tags <- c(.tags, stringr::str_c(base_name, ":", latest_tag))
   }
 

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -535,8 +535,8 @@ extra$stack[[1]]$tags <- .generate_tags(
 )
 ## geospatial-dev-osgeo
 extra$stack[[2]]$FROM <- stringr::str_c("rocker/verse:", r_latest_version)
-extra$stack[[2]]$tags <- .outer_paste(
-  list(c("docker.io/rocker/geospatial", "ghcr.io/rocker-org/geospatial"), ":dev-osgeo")
+extra$stack[[2]]$tags <- stringr::str_c(
+  c("docker.io/rocker/", "ghcr.io/rocker-org/"), "geospatial:dev-osgeo"
 )
 extra$stack[[2]]$ENV$PROJ_VERSION <- .latest_version_of_git_repo("https://github.com/OSGeo/PROJ.git")
 extra$stack[[2]]$ENV$GDAL_VERSION <- .latest_version_of_git_repo("https://github.com/OSGeo/gdal.git")

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -140,22 +140,22 @@ library(gert)
                            use_latest_tag = TRUE,
                            tag_suffix = "",
                            latest_tag = "latest") {
-  list_tags <- list(stringr::str_c(base_name, ":", r_version, tag_suffix))
+  .tags <- stringr::str_c(base_name, ":", r_version, tag_suffix)
 
   r_minor_version <- stringr::str_extract(r_version, "^\\d+\\.\\d+")
   r_major_version <- stringr::str_extract(r_version, "^\\d+")
 
   if (r_minor_latest == TRUE) {
-    list_tags <- c(list_tags, list(stringr::str_c(base_name, ":", r_minor_version, tag_suffix)))
+    .tags <- c(.tags, stringr::str_c(base_name, ":", r_minor_version, tag_suffix))
   }
   if (r_major_latest == TRUE) {
-    list_tags <- c(list_tags, list(stringr::str_c(base_name, ":", r_major_version, tag_suffix)))
+    .tags <- c(.tags, stringr::str_c(base_name, ":", r_major_version, tag_suffix))
   }
   if (r_latest == TRUE & use_latest_tag == TRUE) {
-    list_tags <- c(list_tags, list(stringr::str_c(base_name, ":", latest_tag)))
+    .tags <- c(.tags, stringr::str_c(base_name, ":", latest_tag))
   }
 
-  return(list_tags)
+  return(as.list(.tags))
 }
 
 

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -423,7 +423,7 @@ df_r <- rversions::r_versions() |>
     r_release_date = as.Date(date),
     r_freeze_date = dplyr::lead(r_release_date, 1) - 1
   ) |>
-  dplyr::filter(readr::parse_number(r_version) >= 4.0) |>
+  dplyr::filter(package_version(r_version) >= package_version("4.0.0")) |>
   dplyr::arrange(r_release_date)
 
 # Ubuntu versions data from the Ubuntu local csv file.
@@ -492,9 +492,10 @@ df_args <- df_r |>
   )
 
 
-r_latest_version <- df_args |>
-  dplyr::slice_max(r_release_date, with_ties = FALSE) |>
-  dplyr::pull(r_version)
+r_latest_version <- df_args$r_version |>
+  package_version() |>
+  max() |>
+  as.character()
 rstudio_latest_version <- df_args |>
   dplyr::slice_max(rstudio_commit_date, with_ties = FALSE) |>
   dplyr::pull(rstudio_version)

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -132,6 +132,14 @@ library(gert)
     as.character()
 }
 
+.outer_paste <- function(.list) {
+  .paste <- function(x, y) outer(x, y, stringr::str_c) |> c()
+  out <- .list |>
+    purrr::reduce(.paste)
+
+  return(out)
+}
+
 .generate_tags <- function(base_name,
                            r_version,
                            r_minor_latest = FALSE,
@@ -140,19 +148,19 @@ library(gert)
                            use_latest_tag = TRUE,
                            tag_suffix = "",
                            latest_tag = "latest") {
-  .tags <- stringr::str_c(base_name, ":", r_version, tag_suffix)
+  .tags <- .outer_paste(list(base_name, ":", r_version, tag_suffix))
 
   r_minor_version <- stringr::str_extract(r_version, "^\\d+\\.\\d+")
   r_major_version <- stringr::str_extract(r_version, "^\\d+")
 
   if (r_minor_latest == TRUE) {
-    .tags <- c(.tags, stringr::str_c(base_name, ":", r_minor_version, tag_suffix))
+    .tags <- c(.tags, .outer_paste(list(base_name, ":", r_minor_version, tag_suffix)))
   }
   if (r_major_latest == TRUE) {
-    .tags <- c(.tags, stringr::str_c(base_name, ":", r_major_version, tag_suffix))
+    .tags <- c(.tags, .outer_paste(list(base_name, ":", r_major_version, tag_suffix)))
   }
   if (r_latest == TRUE && use_latest_tag == TRUE) {
-    .tags <- c(.tags, stringr::str_c(base_name, ":", latest_tag))
+    .tags <- c(.tags, .outer_paste(list(base_name, ":", latest_tag)))
   }
 
   return(as.list(.tags))

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -40,7 +40,9 @@
       "CMD": "[\"R\"]",
       "tags": [
         "docker.io/rocker/r-ver:4.1.3",
-        "docker.io/rocker/r-ver:4.1"
+        "ghcr.io/rocker-org/r-ver:4.1.3",
+        "docker.io/rocker/r-ver:4.1",
+        "ghcr.io/rocker-org/r-ver:4.1"
       ],
       "platforms": [
         "linux/amd64",
@@ -75,7 +77,9 @@
       "EXPOSE": 8787,
       "tags": [
         "docker.io/rocker/rstudio:4.1.3",
-        "docker.io/rocker/rstudio:4.1"
+        "ghcr.io/rocker-org/rstudio:4.1.3",
+        "docker.io/rocker/rstudio:4.1",
+        "ghcr.io/rocker-org/rstudio:4.1"
       ]
     },
     {
@@ -88,7 +92,9 @@
       "RUN": "/rocker_scripts/install_tidyverse.sh",
       "tags": [
         "docker.io/rocker/tidyverse:4.1.3",
-        "docker.io/rocker/tidyverse:4.1"
+        "ghcr.io/rocker-org/tidyverse:4.1.3",
+        "docker.io/rocker/tidyverse:4.1",
+        "ghcr.io/rocker-org/tidyverse:4.1"
       ]
     },
     {
@@ -109,7 +115,9 @@
       ],
       "tags": [
         "docker.io/rocker/verse:4.1.3",
-        "docker.io/rocker/verse:4.1"
+        "ghcr.io/rocker-org/verse:4.1.3",
+        "docker.io/rocker/verse:4.1",
+        "ghcr.io/rocker-org/verse:4.1"
       ]
     },
     {
@@ -122,7 +130,9 @@
       "RUN": "/rocker_scripts/install_geospatial.sh",
       "tags": [
         "docker.io/rocker/geospatial:4.1.3",
-        "docker.io/rocker/geospatial:4.1"
+        "ghcr.io/rocker-org/geospatial:4.1.3",
+        "docker.io/rocker/geospatial:4.1",
+        "ghcr.io/rocker-org/geospatial:4.1"
       ]
     },
     {
@@ -142,7 +152,9 @@
       "EXPOSE": 3838,
       "tags": [
         "docker.io/rocker/shiny:4.1.3",
-        "docker.io/rocker/shiny:4.1"
+        "ghcr.io/rocker-org/shiny:4.1.3",
+        "docker.io/rocker/shiny:4.1",
+        "ghcr.io/rocker-org/shiny:4.1"
       ]
     },
     {
@@ -155,7 +167,9 @@
       "RUN": "/rocker_scripts/install_tidyverse.sh",
       "tags": [
         "docker.io/rocker/shiny-verse:4.1.3",
-        "docker.io/rocker/shiny-verse:4.1"
+        "ghcr.io/rocker-org/shiny-verse:4.1.3",
+        "docker.io/rocker/shiny-verse:4.1",
+        "ghcr.io/rocker-org/shiny-verse:4.1"
       ]
     },
     {
@@ -177,16 +191,22 @@
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.3",
-        "docker.io/rocker/binder:4.1"
+        "ghcr.io/rocker-org/binder:4.1.3",
+        "docker.io/rocker/binder:4.1",
+        "ghcr.io/rocker-org/binder:4.1"
       ]
     },
     {
       "IMAGE": "cuda",
       "tags": [
         "docker.io/rocker/cuda:4.1.3-cuda10.1",
-        "docker.io/rocker/cuda:4.1-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.1.3-cuda10.1",
         "docker.io/rocker/cuda:4.1.3",
+        "ghcr.io/rocker-org/cuda:4.1.3",
+        "docker.io/rocker/cuda:4.1-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.1-cuda10.1",
         "docker.io/rocker/cuda:4.1",
+        "ghcr.io/rocker-org/cuda:4.1",
         "docker.io/rocker/r-ver:4.1.3-cuda10.1"
       ],
       "labels": {
@@ -219,9 +239,13 @@
       "IMAGE": "ml",
       "tags": [
         "docker.io/rocker/ml:4.1.3-cuda10.1",
-        "docker.io/rocker/ml:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.1.3-cuda10.1",
         "docker.io/rocker/ml:4.1.3",
-        "docker.io/rocker/ml:4.1"
+        "ghcr.io/rocker-org/ml:4.1.3",
+        "docker.io/rocker/ml:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.1-cuda10.1",
+        "docker.io/rocker/ml:4.1",
+        "ghcr.io/rocker-org/ml:4.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml",
@@ -249,9 +273,13 @@
       "IMAGE": "ml-verse",
       "tags": [
         "docker.io/rocker/ml-verse:4.1.3-cuda10.1",
-        "docker.io/rocker/ml-verse:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.1.3-cuda10.1",
         "docker.io/rocker/ml-verse:4.1.3",
-        "docker.io/rocker/ml-verse:4.1"
+        "ghcr.io/rocker-org/ml-verse:4.1.3",
+        "docker.io/rocker/ml-verse:4.1-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.1-cuda10.1",
+        "docker.io/rocker/ml-verse:4.1",
+        "ghcr.io/rocker-org/ml-verse:4.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml-verse",
@@ -272,7 +300,9 @@
       "IMAGE": "cuda11",
       "tags": [
         "docker.io/rocker/cuda:4.1.3-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.1.3-cuda11.1",
         "docker.io/rocker/cuda:4.1-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.1-cuda11.1",
         "docker.io/rocker/r-ver:4.1.3-cuda11.1"
       ],
       "labels": {
@@ -314,7 +344,9 @@
       "IMAGE": "ml-cuda11",
       "tags": [
         "docker.io/rocker/ml:4.1.3-cuda11.1",
-        "docker.io/rocker/ml:4.1-cuda11.1"
+        "ghcr.io/rocker-org/ml:4.1.3-cuda11.1",
+        "docker.io/rocker/ml:4.1-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.1-cuda11.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
@@ -340,7 +372,9 @@
       "IMAGE": "ml-verse-cuda11",
       "tags": [
         "docker.io/rocker/ml-verse:4.1.3-cuda11.1",
-        "docker.io/rocker/ml-verse:4.1-cuda11.1"
+        "ghcr.io/rocker-org/ml-verse:4.1.3-cuda11.1",
+        "docker.io/rocker/ml-verse:4.1-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.1-cuda11.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -40,9 +40,13 @@
       "CMD": "[\"R\"]",
       "tags": [
         "docker.io/rocker/r-ver:4.2.0",
+        "ghcr.io/rocker-org/r-ver:4.2.0",
         "docker.io/rocker/r-ver:4.2",
+        "ghcr.io/rocker-org/r-ver:4.2",
         "docker.io/rocker/r-ver:4",
-        "docker.io/rocker/r-ver:latest"
+        "ghcr.io/rocker-org/r-ver:4",
+        "docker.io/rocker/r-ver:latest",
+        "ghcr.io/rocker-org/r-ver:latest"
       ],
       "platforms": [
         "linux/amd64",
@@ -77,9 +81,13 @@
       "EXPOSE": 8787,
       "tags": [
         "docker.io/rocker/rstudio:4.2.0",
+        "ghcr.io/rocker-org/rstudio:4.2.0",
         "docker.io/rocker/rstudio:4.2",
+        "ghcr.io/rocker-org/rstudio:4.2",
         "docker.io/rocker/rstudio:4",
-        "docker.io/rocker/rstudio:latest"
+        "ghcr.io/rocker-org/rstudio:4",
+        "docker.io/rocker/rstudio:latest",
+        "ghcr.io/rocker-org/rstudio:latest"
       ]
     },
     {
@@ -92,9 +100,13 @@
       "RUN": "/rocker_scripts/install_tidyverse.sh",
       "tags": [
         "docker.io/rocker/tidyverse:4.2.0",
+        "ghcr.io/rocker-org/tidyverse:4.2.0",
         "docker.io/rocker/tidyverse:4.2",
+        "ghcr.io/rocker-org/tidyverse:4.2",
         "docker.io/rocker/tidyverse:4",
-        "docker.io/rocker/tidyverse:latest"
+        "ghcr.io/rocker-org/tidyverse:4",
+        "docker.io/rocker/tidyverse:latest",
+        "ghcr.io/rocker-org/tidyverse:latest"
       ]
     },
     {
@@ -115,9 +127,13 @@
       ],
       "tags": [
         "docker.io/rocker/verse:4.2.0",
+        "ghcr.io/rocker-org/verse:4.2.0",
         "docker.io/rocker/verse:4.2",
+        "ghcr.io/rocker-org/verse:4.2",
         "docker.io/rocker/verse:4",
-        "docker.io/rocker/verse:latest"
+        "ghcr.io/rocker-org/verse:4",
+        "docker.io/rocker/verse:latest",
+        "ghcr.io/rocker-org/verse:latest"
       ]
     },
     {
@@ -130,9 +146,13 @@
       "RUN": "/rocker_scripts/install_geospatial.sh",
       "tags": [
         "docker.io/rocker/geospatial:4.2.0",
+        "ghcr.io/rocker-org/geospatial:4.2.0",
         "docker.io/rocker/geospatial:4.2",
+        "ghcr.io/rocker-org/geospatial:4.2",
         "docker.io/rocker/geospatial:4",
-        "docker.io/rocker/geospatial:latest"
+        "ghcr.io/rocker-org/geospatial:4",
+        "docker.io/rocker/geospatial:latest",
+        "ghcr.io/rocker-org/geospatial:latest"
       ]
     },
     {
@@ -152,9 +172,13 @@
       "EXPOSE": 3838,
       "tags": [
         "docker.io/rocker/shiny:4.2.0",
+        "ghcr.io/rocker-org/shiny:4.2.0",
         "docker.io/rocker/shiny:4.2",
+        "ghcr.io/rocker-org/shiny:4.2",
         "docker.io/rocker/shiny:4",
-        "docker.io/rocker/shiny:latest"
+        "ghcr.io/rocker-org/shiny:4",
+        "docker.io/rocker/shiny:latest",
+        "ghcr.io/rocker-org/shiny:latest"
       ]
     },
     {
@@ -167,9 +191,13 @@
       "RUN": "/rocker_scripts/install_tidyverse.sh",
       "tags": [
         "docker.io/rocker/shiny-verse:4.2.0",
+        "ghcr.io/rocker-org/shiny-verse:4.2.0",
         "docker.io/rocker/shiny-verse:4.2",
+        "ghcr.io/rocker-org/shiny-verse:4.2",
         "docker.io/rocker/shiny-verse:4",
-        "docker.io/rocker/shiny-verse:latest"
+        "ghcr.io/rocker-org/shiny-verse:4",
+        "docker.io/rocker/shiny-verse:latest",
+        "ghcr.io/rocker-org/shiny-verse:latest"
       ]
     },
     {
@@ -191,22 +219,34 @@
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.0",
+        "ghcr.io/rocker-org/binder:4.2.0",
         "docker.io/rocker/binder:4.2",
+        "ghcr.io/rocker-org/binder:4.2",
         "docker.io/rocker/binder:4",
-        "docker.io/rocker/binder:latest"
+        "ghcr.io/rocker-org/binder:4",
+        "docker.io/rocker/binder:latest",
+        "ghcr.io/rocker-org/binder:latest"
       ]
     },
     {
       "IMAGE": "cuda",
       "tags": [
         "docker.io/rocker/cuda:4.2.0-cuda10.1",
-        "docker.io/rocker/cuda:4.2-cuda10.1",
-        "docker.io/rocker/cuda:4-cuda10.1",
-        "docker.io/rocker/cuda:cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.2.0-cuda10.1",
         "docker.io/rocker/cuda:4.2.0",
+        "ghcr.io/rocker-org/cuda:4.2.0",
+        "docker.io/rocker/cuda:4.2-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4.2-cuda10.1",
         "docker.io/rocker/cuda:4.2",
+        "ghcr.io/rocker-org/cuda:4.2",
+        "docker.io/rocker/cuda:4-cuda10.1",
+        "ghcr.io/rocker-org/cuda:4-cuda10.1",
         "docker.io/rocker/cuda:4",
+        "ghcr.io/rocker-org/cuda:4",
+        "docker.io/rocker/cuda:cuda10.1",
+        "ghcr.io/rocker-org/cuda:cuda10.1",
         "docker.io/rocker/cuda:latest",
+        "ghcr.io/rocker-org/cuda:latest",
         "docker.io/rocker/r-ver:4.2.0-cuda10.1"
       ],
       "labels": {
@@ -239,13 +279,21 @@
       "IMAGE": "ml",
       "tags": [
         "docker.io/rocker/ml:4.2.0-cuda10.1",
-        "docker.io/rocker/ml:4.2-cuda10.1",
-        "docker.io/rocker/ml:4-cuda10.1",
-        "docker.io/rocker/ml:cuda10.1",
+        "ghcr.io/rocker-org/ml:4.2.0-cuda10.1",
         "docker.io/rocker/ml:4.2.0",
+        "ghcr.io/rocker-org/ml:4.2.0",
+        "docker.io/rocker/ml:4.2-cuda10.1",
+        "ghcr.io/rocker-org/ml:4.2-cuda10.1",
         "docker.io/rocker/ml:4.2",
+        "ghcr.io/rocker-org/ml:4.2",
+        "docker.io/rocker/ml:4-cuda10.1",
+        "ghcr.io/rocker-org/ml:4-cuda10.1",
         "docker.io/rocker/ml:4",
-        "docker.io/rocker/ml:latest"
+        "ghcr.io/rocker-org/ml:4",
+        "docker.io/rocker/ml:cuda10.1",
+        "ghcr.io/rocker-org/ml:cuda10.1",
+        "docker.io/rocker/ml:latest",
+        "ghcr.io/rocker-org/ml:latest"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml",
@@ -273,13 +321,21 @@
       "IMAGE": "ml-verse",
       "tags": [
         "docker.io/rocker/ml-verse:4.2.0-cuda10.1",
-        "docker.io/rocker/ml-verse:4.2-cuda10.1",
-        "docker.io/rocker/ml-verse:4-cuda10.1",
-        "docker.io/rocker/ml-verse:cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.2.0-cuda10.1",
         "docker.io/rocker/ml-verse:4.2.0",
+        "ghcr.io/rocker-org/ml-verse:4.2.0",
+        "docker.io/rocker/ml-verse:4.2-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4.2-cuda10.1",
         "docker.io/rocker/ml-verse:4.2",
+        "ghcr.io/rocker-org/ml-verse:4.2",
+        "docker.io/rocker/ml-verse:4-cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:4-cuda10.1",
         "docker.io/rocker/ml-verse:4",
-        "docker.io/rocker/ml-verse:latest"
+        "ghcr.io/rocker-org/ml-verse:4",
+        "docker.io/rocker/ml-verse:cuda10.1",
+        "ghcr.io/rocker-org/ml-verse:cuda10.1",
+        "docker.io/rocker/ml-verse:latest",
+        "ghcr.io/rocker-org/ml-verse:latest"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml-verse",
@@ -300,9 +356,13 @@
       "IMAGE": "cuda11",
       "tags": [
         "docker.io/rocker/cuda:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.2.0-cuda11.1",
         "docker.io/rocker/cuda:4.2-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4.2-cuda11.1",
         "docker.io/rocker/cuda:4-cuda11.1",
+        "ghcr.io/rocker-org/cuda:4-cuda11.1",
         "docker.io/rocker/cuda:cuda11.1",
+        "ghcr.io/rocker-org/cuda:cuda11.1",
         "docker.io/rocker/r-ver:4.2.0-cuda11.1"
       ],
       "labels": {
@@ -344,9 +404,13 @@
       "IMAGE": "ml-cuda11",
       "tags": [
         "docker.io/rocker/ml:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.2.0-cuda11.1",
         "docker.io/rocker/ml:4.2-cuda11.1",
+        "ghcr.io/rocker-org/ml:4.2-cuda11.1",
         "docker.io/rocker/ml:4-cuda11.1",
-        "docker.io/rocker/ml:cuda11.1"
+        "ghcr.io/rocker-org/ml:4-cuda11.1",
+        "docker.io/rocker/ml:cuda11.1",
+        "ghcr.io/rocker-org/ml:cuda11.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml (CUDA 11)",
@@ -372,9 +436,13 @@
       "IMAGE": "ml-verse-cuda11",
       "tags": [
         "docker.io/rocker/ml-verse:4.2.0-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.2.0-cuda11.1",
         "docker.io/rocker/ml-verse:4.2-cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:4.2-cuda11.1",
         "docker.io/rocker/ml-verse:4-cuda11.1",
-        "docker.io/rocker/ml-verse:cuda11.1"
+        "ghcr.io/rocker-org/ml-verse:4-cuda11.1",
+        "docker.io/rocker/ml-verse:cuda11.1",
+        "ghcr.io/rocker-org/ml-verse:cuda11.1"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/ml-verse (CUDA 11)",

--- a/stacks/extra.json
+++ b/stacks/extra.json
@@ -33,7 +33,9 @@
       "IMAGE": "geospatial-ubuntugis",
       "tags": [
         "docker.io/rocker/geospatial:4.2.0-ubuntugis",
-        "docker.io/rocker/geospatial:ubuntugis"
+        "ghcr.io/rocker-org/geospatial:4.2.0-ubuntugis",
+        "docker.io/rocker/geospatial:ubuntugis",
+        "ghcr.io/rocker-org/geospatial:ubuntugis"
       ],
       "labels": {
         "org.opencontainers.image.title": "rocker/geospatial (ubuntugis)",
@@ -45,9 +47,7 @@
     },
     {
       "IMAGE": "geospatial-dev-osgeo",
-      "tags": [
-        "docker.io/rocker/geospatial:dev-osgeo"
-      ],
+      "tags": ["docker.io/rocker/geospatial:dev-osgeo", "ghcr.io/rocker-org/geospatial:dev-osgeo"],
       "labels": {
         "org.opencontainers.image.title": "rocker/geospatial (dev-osgeo)",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image."


### PR DESCRIPTION
Close  #371

Add tags like `ghcr.io/rocker-org/r-ver:latest` to push the same images to GitHub Container registry as to DockerHub.
Of course, the GitHub Actions workflow files also need a little updating to push images to ghcr.