### PR TITLE
Avoiding build errors of dev-osgeo due to lack of the `ncmeta` package etc.

### DIFF
--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -160,7 +160,7 @@ R CMD build sf
 R CMD INSTALL sf
 rm -rf sf*
 R CMD build stars
-R CMD INSTALL stars --no-build-vignettes
+R CMD INSTALL stars --no-build-vignettes --no-manual
 rm -rf stars*
 
 # Clean up


### PR DESCRIPTION
Fixes in #459 was inadequate.