### PR TITLE
[CI] Workaround for the `fatal: unsafe repogitory` error on jobs on containers

### DIFF
--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: rocker/tidyverse@sha256:84363da59e10b3bf14e2db6db9aaf213d281b15b00518e93be70661aaa98847e
+      image: rocker/tidyverse:latest
     steps:
       - uses: actions/checkout@v3
       - name: install packages

--- a/.github/workflows/dockerfiles.yml
+++ b/.github/workflows/dockerfiles.yml
@@ -13,6 +13,8 @@ jobs:
       image: rocker/tidyverse:latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set as safe for following git commands
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: install packages
         run: |
           install2.r --error --skipinstalled -n -1 pak

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -60,7 +60,7 @@ jobs:
     needs: inspect
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse@sha256:84363da59e10b3bf14e2db6db9aaf213d281b15b00518e93be70661aaa98847e
+      image: rocker/tidyverse:latest
     steps:
       - name: Checkout main
         uses: actions/checkout@v3

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v3
+      - name: Set as safe for following git commands
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout wiki
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Related to actions/checkout#766

We have been getting around this by pinning to the older image (`rocker/tidyverse@sha256:84363da59e10b3bf14e2db6db9aaf213d281b15b00518e93be70661aaa98847e`), but I will add a workaround step and go back to using the latest image.