### PR TITLE
Make `install_quarto.sh` only install quarto cli (no R pakcages)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # News
 
+## 2022-06
+
+### Changes in rocker_scripts
+
+- `install_quarto.sh` was changed to not install R packages and only install quarto cli.
+  ([#487](https://github.com/rocker-org/rocker-versioned2/pull/487))
+
+### Changes in pre-built images
+
+- New builds of `rocker/verse` and `rocker/ml-verse` for R >= 4.1.0 no longer install the quarto R package.
+  ([#487](https://github.com/rocker-org/rocker-versioned2/pull/487))
+
 ## 2022-05
 
 ### Changes in rocker_scripts

--- a/scripts/install_julia.sh
+++ b/scripts/install_julia.sh
@@ -23,7 +23,7 @@ if [ "$ARCH_LONG" = "x86_64" ]; then
     ARCH_SHORT="x64"
 fi
 
-apt_install wget
+apt_install wget ca-certificates
 
 install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
     yaml \

--- a/scripts/install_pandoc.sh
+++ b/scripts/install_pandoc.sh
@@ -23,7 +23,7 @@ function apt_install() {
     fi
 }
 
-apt_install wget
+apt_install wget ca-certificates
 
 if [ -x "$(command -v pandoc)" ]; then
     INSTALLED_PANDOC_VERSION=$(pandoc --version 2>/dev/null | head -n 1 | grep -oP '[\d\.]+$')

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -67,15 +67,5 @@ if [ "$QUARTO_VERSION" != "$INSTALLED_QUARTO_VERSION" ]; then
 
 fi
 
-# Install the quarto R package
-install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
-    knitr \
-    quarto
-
 # Clean up
 rm -rf /var/lib/apt/lists/*
-rm -rf /tmp/downloaded_packages
-
-## Strip binary installed lybraries from RSPM
-## https://github.com/rocker-org/rocker-versioned2/issues/340
-strip /usr/local/lib/R/site-library/*/libs/*.so

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -27,7 +27,7 @@ function apt_install() {
     fi
 }
 
-apt_install wget
+apt_install wget ca-certificates
 
 if [ -x "$(command -v quarto)" ]; then
     INSTALLED_QUARTO_VERSION=$(quarto --version)

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -21,6 +21,7 @@ function apt_install() {
 }
 
 apt_install \
+    ca-certificates \
     lsb-release \
     file \
     git \

--- a/scripts/install_s6init.sh
+++ b/scripts/install_s6init.sh
@@ -23,7 +23,7 @@ fi
 
 DOWNLOAD_FILE=s6-overlay-${ARCH}.tar.gz
 
-apt_install wget
+apt_install wget ca-certificates
 
 ## Set up S6 init system
 if [ -f "/rocker_scripts/.s6_version" ] && [ "$S6_VERSION" = "$(cat /rocker_scripts/.s6_version)" ]; then

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -13,7 +13,7 @@ function apt_install() {
     fi
 }
 
-apt_install wget
+apt_install wget ca-certificates
 
 cd /opt
 wget https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -58,6 +58,12 @@
       "tag": "cuda11.1",
       "script_name": "config_R_cuda.sh",
       "script_arg": "none"
+    },
+    {
+      "base_image": "debian",
+      "tag": "stable-slim",
+      "script_name": "install_quarto.sh",
+      "script_arg": "none"
     }
   ]
 }


### PR DESCRIPTION
Currently, a preview version of the quarto cli is already included with RStudio and is positioned as an experimental feature, but once the quarto cli reaches version 1.0, RStudio is expected to use quarto by default.

This means that `install_quarto.sh` must be included in `rocker/rstudio`, just as `install_pandoc.sh` is currently run for `rocker/rstudio`.

This PR removes the R package installation process from `install_quarto.sh`, since the R packages are not needed at all to use the quarto cli and users can install what they need on their own as needed.

As a side effect, `install_quarto.sh` should be executable on many debian base images.
This PR will also add that test case.