### PR TITLE
Deprecate the environment variable `USER` for changing the user name of the RStudio user

### DIFF
--- a/scripts/init_userconf.sh
+++ b/scripts/init_userconf.sh
@@ -40,6 +40,15 @@ if [ "$USERID" -lt 1000 ]; then # Probably a macOS user, https://github.com/rock
     fi
 fi
 
+if [ "$USER" != "$DEFAULT_USER" ]; then
+    printf "\n\n"
+    tput bold
+    printf "Settings by \e[31m\`-e USER=<new username>\`\e[39m is now deprecated and will be removed in the future.\n"
+    printf "Please do note use the USER environment variable.\n"
+    tput sgr0
+    printf "\n\n"
+fi
+
 if [ "$USERID" -ne 1000 ]; then ## Configure user with a different USERID if requested.
     echo "deleting the default user"
     userdel "$DEFAULT_USER"


### PR DESCRIPTION
Suggested by https://github.com/rocker-org/rocker-versioned2/issues/489#issuecomment-1159693316

This process is buggy, so I think it make sense to remove it.
If we want to change the user name, just write a Dockerfile like this

```dockerfile
FROM rocker/rstudio:4.2.0
ENV DEFAULT_USER=new_user
RUN usermod -l "$DEFAULT_USER" rstudio \
    && groupmod -n "$DEFAULT_USER" rstudio \
    && usermod -d /home/"$DEFAULT_USER" -m "$DEFAULT_USER"
```