### PR TITLE
[CI] Prevent unnecessary builds

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
     paths:
-      - "scripts/*"
       - "dockerfiles/*_devel.Dockerfile"
   workflow_run:
     workflows:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ When a new version of R or RStudio is released, GitHub Actions will automaticall
 ### Update pre-built images
 
 Latest R version images will be built on a rolling basis;
-when the definition files or Rocker scripts are updated, they are immediately built by GitHub Actions.
+when the Dockerfiles are updated, they are immediately built by GitHub Actions.
 
 Non-latest R version images will be built when a new R version is released.
 At this time, a tag and a GitHub release will also be created.

--- a/bakefiles/4.0.0.docker-bake.json
+++ b/bakefiles/4.0.0.docker-bake.json
@@ -59,7 +59,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -81,7 +81,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -103,7 +103,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -125,7 +125,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -147,7 +147,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -169,7 +169,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -191,7 +191,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.0"
       ],
       "cache-to": [
         "type=inline"
@@ -215,7 +215,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -238,7 +238,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -261,7 +261,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.0.1.docker-bake.json
+++ b/bakefiles/4.0.1.docker-bake.json
@@ -47,7 +47,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.1"
       ],
       "cache-to": [
         "type=inline"
@@ -203,7 +203,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -226,7 +226,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -249,7 +249,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.0.2.docker-bake.json
+++ b/bakefiles/4.0.2.docker-bake.json
@@ -47,7 +47,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.2"
       ],
       "cache-to": [
         "type=inline"
@@ -203,7 +203,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -226,7 +226,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -249,7 +249,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.0.3.docker-bake.json
+++ b/bakefiles/4.0.3.docker-bake.json
@@ -47,7 +47,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.3"
       ],
       "cache-to": [
         "type=inline"
@@ -203,7 +203,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -226,7 +226,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -249,7 +249,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -272,7 +272,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.3-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -294,7 +294,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.3-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -316,7 +316,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.3-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.0.4.docker-bake.json
+++ b/bakefiles/4.0.4.docker-bake.json
@@ -47,7 +47,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.4"
       ],
       "cache-to": [
         "type=inline"
@@ -203,7 +203,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.4-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -226,7 +226,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.4-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -249,7 +249,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.4-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -272,7 +272,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.4-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -294,7 +294,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.4-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -316,7 +316,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.4-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.0.5.docker-bake.json
+++ b/bakefiles/4.0.5.docker-bake.json
@@ -49,7 +49,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -72,7 +72,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -95,7 +95,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -118,7 +118,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -141,7 +141,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -164,7 +164,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -187,7 +187,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.0.5"
       ],
       "cache-to": [
         "type=inline"
@@ -213,7 +213,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.5-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -238,7 +238,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.5-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -263,7 +263,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.5-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -287,7 +287,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.0.5-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -310,7 +310,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.0.5-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -333,7 +333,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.0.5-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.1.0.docker-bake.json
+++ b/bakefiles/4.1.0.docker-bake.json
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -201,7 +201,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.1.0"
       ],
       "cache-to": [
         "type=inline"
@@ -225,7 +225,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.1.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -248,7 +248,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -271,7 +271,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -316,7 +316,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.0-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -338,7 +338,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.0-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.1.1.docker-bake.json
+++ b/bakefiles/4.1.1.docker-bake.json
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -201,7 +201,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.1.1"
       ],
       "cache-to": [
         "type=inline"
@@ -225,7 +225,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.1.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -248,7 +248,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -271,7 +271,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -316,7 +316,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.1-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -338,7 +338,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.1-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.1.2.docker-bake.json
+++ b/bakefiles/4.1.2.docker-bake.json
@@ -69,7 +69,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -91,7 +91,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -135,7 +135,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -157,7 +157,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -179,7 +179,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -201,7 +201,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.1.2"
       ],
       "cache-to": [
         "type=inline"
@@ -225,7 +225,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.1.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -248,7 +248,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -271,7 +271,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.2-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -316,7 +316,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.2-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -338,7 +338,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.2-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.1.3.docker-bake.json
+++ b/bakefiles/4.1.3.docker-bake.json
@@ -75,7 +75,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -100,7 +100,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -125,7 +125,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -150,7 +150,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -175,7 +175,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -200,7 +200,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -225,7 +225,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.1.3"
       ],
       "cache-to": [
         "type=inline"
@@ -255,7 +255,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.1.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -284,7 +284,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -313,7 +313,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.3-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -364,7 +364,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.1.3-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -389,7 +389,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.1.3-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.2.0.docker-bake.json
+++ b/bakefiles/4.2.0.docker-bake.json
@@ -71,7 +71,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -94,7 +94,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -117,7 +117,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -140,7 +140,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -163,7 +163,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -186,7 +186,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -209,7 +209,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.2.0"
       ],
       "cache-to": [
         "type=inline"
@@ -235,7 +235,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.2.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -260,7 +260,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.2.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -285,7 +285,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.2.0-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -332,7 +332,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.2.0-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -355,7 +355,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.2.0-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/4.2.1.docker-bake.json
+++ b/bakefiles/4.2.1.docker-bake.json
@@ -83,7 +83,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -112,7 +112,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -141,7 +141,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -170,7 +170,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -199,7 +199,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -228,7 +228,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -257,7 +257,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:4.2.1"
       ],
       "cache-to": [
         "type=inline"
@@ -295,7 +295,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/cuda:4.2.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -332,7 +332,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.2.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -369,7 +369,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.2.1-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -428,7 +428,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:4.2.1-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -457,7 +457,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:4.2.1-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/core-latest-daily.docker-bake.json
+++ b/bakefiles/core-latest-daily.docker-bake.json
@@ -28,7 +28,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:latest-daily"
       ],
       "cache-to": [
         "type=inline"
@@ -49,7 +49,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:latest-daily"
       ],
       "cache-to": [
         "type=inline"
@@ -70,7 +70,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:latest-daily"
       ],
       "cache-to": [
         "type=inline"

--- a/bakefiles/devel.docker-bake.json
+++ b/bakefiles/devel.docker-bake.json
@@ -29,7 +29,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/r-ver:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -50,7 +50,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/rstudio:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -71,7 +71,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/tidyverse:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -92,7 +92,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/verse:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -113,7 +113,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/geospatial:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -134,7 +134,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -155,7 +155,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/shiny-verse:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -176,7 +176,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/binder:devel"
       ],
       "cache-to": [
         "type=inline"
@@ -199,7 +199,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/r-ver:devel-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -221,7 +221,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:devel-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -243,7 +243,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:devel-cuda10.1"
       ],
       "cache-to": [
         "type=inline"
@@ -265,7 +265,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/r-ver:devel-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -286,7 +286,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml:devel-cuda11.1"
       ],
       "cache-to": [
         "type=inline"
@@ -307,7 +307,7 @@
         "linux/amd64"
       ],
       "cache-from": [
-        ""
+        "docker.io/rocker/ml-verse:devel-cuda11.1"
       ],
       "cache-to": [
         "type=inline"

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -48,7 +48,7 @@ library(stringr)
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64")),
       `cache-from` = purrr::map(value, "cache-from", .default = NULL),
       `cache-to` = purrr::map(value, "cache-to", .default = list("type=inline")),
-      base_image = map_chr(value, "FROM")
+      base_image = purrr::map_chr(value, "FROM")
     ) |>
     dplyr::rowwise() |>
     dplyr::mutate(

--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -46,7 +46,7 @@ library(stringr)
         ~ if (!is.null(.x$tags)) .x$tags else list(stringr::str_c("docker.io/rocker/", .x$IMAGE, ":", stack_tag))
       ),
       platforms = purrr::map(value, "platforms", .default = list("linux/amd64")),
-      `cache-from` = purrr::map(value, "cache-from", .default = list("")),
+      `cache-from` = purrr::map(value, "cache-from", .default = NULL),
       `cache-to` = purrr::map(value, "cache-to", .default = list("type=inline")),
       base_image = map_chr(value, "FROM")
     ) |>
@@ -56,7 +56,8 @@ library(stringr)
         labels,
         org.opencontainers.image.base.name = .image_full_name(base_image),
         org.opencontainers.image.version = .version_or_null(stack_tag)
-      ))
+      )),
+      `cache-from` = list(if (is.null(`cache-from`)) tags[1] else `cache-from`)
     ) |>
     dplyr::ungroup() |>
     dplyr::select(


### PR DESCRIPTION
The build has been executed twice in the past two days.
Also, with the release of RStudio today (#502), this will cause builds to occur for three days in a row.
This PR will make the following two changes to reduce the frequent builds.

1. Stop automatic builds when script updates occur. (e.g. #500)
2. Use cache on all images to avoid unnecessary builds in the absence of updates. (e.g. #502)