### PR TITLE
Updates for the first quarto cli stable release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,22 @@
   ([#494](https://github.com/rocker-org/rocker-versioned2/pull/494))
 - `install_python.sh` no longer installs pyenv.
   ([#494](https://github.com/rocker-org/rocker-versioned2/pull/494))
+- Update `install_quarto.sh` for the first stable release of quarto cli.
+  ([#506](https://github.com/rocker-org/rocker-versioned2/pull/506))
+  - The default behavior of `install_quarto.sh` has been changed so that if quarto bundled with RStudio is detected,
+    it will use the quarto cli bundled with RStudio instead of installing quarto cli.
+  - Specifying `./install_quarto.sh prerelease` now installs the latest prerelease version of quarto cli.
 
 ### Changes in pre-built images
 
 - `rocker/binder`, `rocker/cuda`, `rocker/ml` and `rocker/ml-verse` no longer configure a default python venv and
   no longer installs pyenv.
   ([#494](https://github.com/rocker-org/rocker-versioned2/pull/494))
+- Update to address RStudio Server now bundling stable release version of quarto cli.
+  ([#506](https://github.com/rocker-org/rocker-versioned2/pull/506))
+  - New builds of `rocker/verse` and `rocker/ml-verse` for 4.1.0 <= R <= 4.2.0 will install quarto cli version 1.0.36.
+  - New builds of `rocker/rstudio` and `rocker/ml` for R >= 4.2.1 (with RStudio Server v2022.07.1+554 or later)
+    will be configured to use the quarto cli bundled with RStudio Server system-wide.
 
 ## 2022-06
 

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -551,7 +551,7 @@ df_args |>
   dplyr::group_by(r_version) |>
   dplyr::slice_tail(n = 1) |>
   dplyr::ungroup() |>
-  dplyr::slice_max(r_release_date, n = 2, with_ties = FALSE) |>
+  dplyr::slice_max(r_release_date, n = 1, with_ties = FALSE) |>
   dplyr::select(
     r_version,
     ubuntu_series,

--- a/dockerfiles/ml-cuda11_4.2.1.Dockerfile
+++ b/dockerfiles/ml-cuda11_4.2.1.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 EXPOSE 8787

--- a/dockerfiles/ml-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-cuda11_devel.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 EXPOSE 8787

--- a/dockerfiles/ml-verse-cuda11_4.1.0.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.0.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.1.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.1.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.2.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.2.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/03/09/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse-cuda11_4.1.3.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.1.3.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/04/21/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse-cuda11_4.2.0.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.2.0.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/06/22/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse-cuda11_4.2.1.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_4.2.1.Dockerfile
@@ -6,8 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse-cuda11_devel.Dockerfile
+++ b/dockerfiles/ml-verse-cuda11_devel.Dockerfile
@@ -6,8 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_4.1.0.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.0.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse_4.1.1.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.1.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse_4.1.2.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.2.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/03/09/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse_4.1.3.Dockerfile
+++ b/dockerfiles/ml-verse_4.1.3.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/04/21/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse_4.2.0.Dockerfile
+++ b/dockerfiles/ml-verse_4.2.0.Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/06/22/tlnet
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/ml-verse_4.2.1.Dockerfile
+++ b/dockerfiles/ml-verse_4.2.1.Dockerfile
@@ -6,8 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml-verse_devel.Dockerfile
+++ b/dockerfiles/ml-verse_devel.Dockerfile
@@ -6,8 +6,6 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_geospatial.sh

--- a/dockerfiles/ml_4.2.1.Dockerfile
+++ b/dockerfiles/ml_4.2.1.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 EXPOSE 8787

--- a/dockerfiles/ml_devel.Dockerfile
+++ b/dockerfiles/ml_devel.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 EXPOSE 8787

--- a/dockerfiles/rstudio_4.2.1.Dockerfile
+++ b/dockerfiles/rstudio_4.2.1.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/rstudio_devel.Dockerfile
+++ b/dockerfiles/rstudio_devel.Dockerfile
@@ -6,13 +6,15 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
       org.opencontainers.image.authors="Carl Boettiger <cboettig@ropensci.org>"
 
 ENV S6_VERSION=v2.1.0.2
-ENV RSTUDIO_VERSION=2022.07.0+548
+ENV RSTUDIO_VERSION=2022.07.1+554
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/rstudio_latest-daily.Dockerfile
+++ b/dockerfiles/rstudio_latest-daily.Dockerfile
@@ -9,10 +9,12 @@ ENV S6_VERSION=v2.1.0.2
 ENV RSTUDIO_VERSION=daily
 ENV DEFAULT_USER=rstudio
 ENV PANDOC_VERSION=default
+ENV QUARTO_VERSION=default
 ENV PATH=/usr/lib/rstudio-server/bin:$PATH
 
 RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
+RUN /rocker_scripts/install_quarto.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/verse_4.1.0.Dockerfile
+++ b/dockerfiles/verse_4.1.0.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/08/09/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_4.1.1.Dockerfile
+++ b/dockerfiles/verse_4.1.1.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2021/10/31/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_4.1.2.Dockerfile
+++ b/dockerfiles/verse_4.1.2.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/03/09/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_4.1.3.Dockerfile
+++ b/dockerfiles/verse_4.1.3.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/04/21/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_4.2.0.Dockerfile
+++ b/dockerfiles/verse_4.2.0.Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://www.texlive.info/tlnet-archive/2022/06/22/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
+ENV QUARTO_VERSION=1.0.36
 
 RUN /rocker_scripts/install_verse.sh
 RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_4.2.1.Dockerfile
+++ b/dockerfiles/verse_4.2.1.Dockerfile
@@ -7,7 +7,5 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_devel.Dockerfile
+++ b/dockerfiles/verse_devel.Dockerfile
@@ -7,7 +7,5 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh

--- a/dockerfiles/verse_latest-daily.Dockerfile
+++ b/dockerfiles/verse_latest-daily.Dockerfile
@@ -7,7 +7,5 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
 
 ENV CTAN_REPO=https://mirror.ctan.org/systems/texlive/tlnet
 ENV PATH=$PATH:/usr/local/texlive/bin/linux
-ENV QUARTO_VERSION=latest
 
 RUN /rocker_scripts/install_verse.sh
-RUN /rocker_scripts/install_quarto.sh

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -6,7 +6,8 @@
 ## ex. latest, default, 0.9.16
 ##
 ## 'default' means the version bundled with RStudio if RStudio is installed, but 'latest' otherwise.
-## 'latest' means installing the latest release version.
+## 'latest', 'release' means installing the latest release version.
+## 'prerelease' means installing the latest prerelease version.
 
 set -e
 
@@ -53,8 +54,10 @@ if [ "$QUARTO_VERSION" != "$INSTALLED_QUARTO_VERSION" ]; then
     if [ "$QUARTO_VERSION" = "$BUNDLED_QUARTO_VERSION" ] || [ "$QUARTO_VERSION" = "default" ]; then
         ln -fs "$BUNDLED_QUARTO" /usr/local/bin
     else
-        if [ "$QUARTO_VERSION" = "latest" ]; then
-            QUARTO_DL_URL=$(wget -qO- https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest | grep -oP "(?<=\"browser_download_url\":\s\")https.*${ARCH}\.deb")
+        if [ "$QUARTO_VERSION" = "latest" ] || [ "$RSTUDIO_VERSION" = "release" ]; then
+            QUARTO_DL_URL=$(wget -qO- https://quarto.org/docs/download/_download.json | grep -oP "(?<=\"download_url\":\s\")https.*${ARCH}\.deb")
+        elif [ "$QUARTO_VERSION" = "prerelease" ]; then
+            QUARTO_DL_URL=$(wget -qO- https://quarto.org/docs/download/_prerelease.json | grep -oP "(?<=\"download_url\":\s\")https.*${ARCH}\.deb")
         else
             QUARTO_DL_URL="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${ARCH}.deb"
         fi

--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -13,7 +13,7 @@ set -e
 ## build ARGs
 NCPUS=${NCPUS:--1}
 
-QUARTO_VERSION=${1:-${QUARTO_VERSION:-"latest"}}
+QUARTO_VERSION=${1:-${QUARTO_VERSION:-"default"}}
 # Only amd64 build can be installed now
 ARCH=$(dpkg --print-architecture)
 

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -98,7 +98,7 @@
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -242,7 +242,7 @@
       "FROM": "rocker/ml:4.1.0",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -326,7 +326,7 @@
       "FROM": "rocker/ml:4.1.0-cuda11.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/08/09/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -98,7 +98,7 @@
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -242,7 +242,7 @@
       "FROM": "rocker/ml:4.1.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -326,7 +326,7 @@
       "FROM": "rocker/ml:4.1.1-cuda11.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2021/10/31/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -98,7 +98,7 @@
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/03/09/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -242,7 +242,7 @@
       "FROM": "rocker/ml:4.1.2",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/03/09/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -326,7 +326,7 @@
       "FROM": "rocker/ml:4.1.2-cuda11.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/03/09/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -107,7 +107,7 @@
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/04/21/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -284,7 +284,7 @@
       "FROM": "rocker/ml:4.1.3",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/04/21/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -377,7 +377,7 @@
       "FROM": "rocker/ml:4.1.3-cuda11.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/04/21/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -101,7 +101,7 @@
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/06/22/tlnet",
         "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -256,7 +256,7 @@
       "FROM": "rocker/ml:4.2.0",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/06/22/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
@@ -343,7 +343,7 @@
       "FROM": "rocker/ml:4.2.0-cuda11.1",
       "ENV": {
         "CTAN_REPO": "https://www.texlive.info/tlnet-archive/2022/06/22/tlnet",
-        "QUARTO_VERSION": "latest"
+        "QUARTO_VERSION": "1.0.36"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",

--- a/stacks/4.2.1.json
+++ b/stacks/4.2.1.json
@@ -68,14 +68,16 @@
       "FROM": "rocker/r-ver:4.2.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
-        "/rocker_scripts/install_pandoc.sh"
+        "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787,
@@ -118,12 +120,10 @@
       "FROM": "rocker/tidyverse:4.2.1",
       "ENV": {
         "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "PATH": "$PATH:/usr/local/texlive/bin/linux"
       },
       "RUN": [
-        "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh"
+        "/rocker_scripts/install_verse.sh"
       ],
       "tags": [
         "docker.io/rocker/verse:4.2.1",
@@ -300,14 +300,16 @@
       "FROM": "rocker/cuda:4.2.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_tidyverse.sh"
       ],
       "CMD": "[\"/init\"]",
@@ -339,12 +341,10 @@
       },
       "FROM": "rocker/ml:4.2.1",
       "ENV": {
-        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "QUARTO_VERSION": "latest"
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_geospatial.sh"
       ]
     },
@@ -413,14 +413,16 @@
       "FROM": "rocker/cuda:4.2.1-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_tidyverse.sh"
       ],
       "CMD": "[\"/init\"]",
@@ -444,12 +446,10 @@
       },
       "FROM": "rocker/ml:4.2.1-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "QUARTO_VERSION": "latest"
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_geospatial.sh"
       ]
     }

--- a/stacks/core-latest-daily.json
+++ b/stacks/core-latest-daily.json
@@ -28,11 +28,13 @@
         "RSTUDIO_VERSION": "daily",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
-        "/rocker_scripts/install_pandoc.sh"
+        "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787
@@ -55,12 +57,10 @@
       "FROM": "rocker/tidyverse:latest-daily",
       "ENV": {
         "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "PATH": "$PATH:/usr/local/texlive/bin/linux"
       },
       "RUN": [
-        "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh"
+        "/rocker_scripts/install_verse.sh"
       ]
     }
   ]

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -48,14 +48,16 @@
       "FROM": "rocker/r-ver:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
-        "/rocker_scripts/install_pandoc.sh"
+        "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787
@@ -78,12 +80,10 @@
       "FROM": "rocker/tidyverse:devel",
       "ENV": {
         "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "PATH": "$PATH:/usr/local/texlive/bin/linux",
-        "QUARTO_VERSION": "latest"
+        "PATH": "$PATH:/usr/local/texlive/bin/linux"
       },
       "RUN": [
-        "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh"
+        "/rocker_scripts/install_verse.sh"
       ]
     },
     {
@@ -182,14 +182,16 @@
       "FROM": "rocker/cuda:devel",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_tidyverse.sh"
       ],
       "CMD": "[\"/init\"]",
@@ -207,12 +209,10 @@
       },
       "FROM": "rocker/ml:devel",
       "ENV": {
-        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "QUARTO_VERSION": "latest"
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_geospatial.sh"
       ]
     },
@@ -261,14 +261,16 @@
       "FROM": "rocker/cuda:devel-cuda11.1",
       "ENV": {
         "S6_VERSION": "v2.1.0.2",
-        "RSTUDIO_VERSION": "2022.07.0+548",
+        "RSTUDIO_VERSION": "2022.07.1+554",
         "DEFAULT_USER": "rstudio",
         "PANDOC_VERSION": "default",
+        "QUARTO_VERSION": "default",
         "PATH": "/usr/lib/rstudio-server/bin:$PATH"
       },
       "RUN": [
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
+        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_tidyverse.sh"
       ],
       "CMD": "[\"/init\"]",
@@ -285,12 +287,10 @@
       },
       "FROM": "rocker/ml:devel-cuda11.1",
       "ENV": {
-        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet",
-        "QUARTO_VERSION": "latest"
+        "CTAN_REPO": "https://mirror.ctan.org/systems/texlive/tlnet"
       },
       "RUN": [
         "/rocker_scripts/install_verse.sh",
-        "/rocker_scripts/install_quarto.sh",
         "/rocker_scripts/install_geospatial.sh"
       ]
     }

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -45,7 +45,7 @@
       "base_image": "rocker/r-ver",
       "tag": "latest",
       "script_name": "install_quarto.sh",
-      "script_arg": "0.9.260"
+      "script_arg": "1.0.36"
     },
     {
       "base_image": "rocker/r-ver",

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -49,6 +49,12 @@
     },
     {
       "base_image": "rocker/r-ver",
+      "tag": "latest",
+      "script_name": "install_quarto.sh",
+      "script_arg": "prerelease"
+    },
+    {
+      "base_image": "rocker/r-ver",
       "tag": "4.0.5",
       "script_name": "install_cuda-11.1.sh",
       "script_arg": "none"


### PR DESCRIPTION
- [x] `install_quarto.sh` use RStudio bundled quarto cli by default.
- [x] Install the latest pre-release version quarto cli <https://quarto.org/docs/download/prerelease.html> by running `./install_quarto.sh prerelease`.
- [x] Move the running `install_quarto.sh` layer from `rocker/verse` to `rocker/rstudio` R >= 4.2.1.
- [x] Install the first release version of quarto cli (v1.0.36) for `rocker/verse` 4.1.0 <= R <= 4.2.0.
- [x] Update NEWS.md