### PR TITLE
[Docs][CI] Change the link syntax on the wiki home from MediaWiki's one to Markdown's to reduce redering time on GitHub

### DIFF
--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -134,7 +134,7 @@ df_all |>
     R = version,
     ImageName = image_title,
     RepoTags = tags,
-    ID = stringr::str_c("[[", id, "|", report_name, "]]"),
+    ID = stringr::str_c("[", id, "](./", report_name, ")"),
     CreatedTime
   )
 ```
@@ -150,7 +150,7 @@ df_all |>
   dplyr::transmute(
     ImageName = image_title,
     RepoTags = tags,
-    ID = stringr::str_c("[[", id, "|", report_name, "]]"),
+    ID = stringr::str_c("[", id, "](./", report_name, ")"),
     CreatedTime
   )
 ```


### PR DESCRIPTION
close #472

Two syntaxes are available for linking on the GitHub wiki, but I have found that the MediaWiki syntax takes a long time to render and sometimes fails to render on wikis with large numbers of pages.

> - If your pages are rendered with Markdown, the link syntax is `[Link Text](full-URL-of-wiki-page)`.
> - With MediaWiki syntax, the link syntax is `[[nameofwikipage|Link Text]]`.

https://docs.github.com/en/communities/documenting-your-project-with-wikis/editing-wiki-content

So change the link syntax and update the wiki home so that it renders correctly.