### PR TITLE
Remove libicu-le-hb0 and libicu4j-* from `rocker/r-ver`

### DIFF
--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -43,7 +43,7 @@ apt-get install -y --no-install-recommends \
     libblas-dev \
     libbz2-* \
     libcurl4 \
-    libicu* \
+    "libicu[0-9][0-9]" \
     liblapack-dev \
     libpcre2* \
     libjpeg-turbo* \


### PR DESCRIPTION
This base image is being flagged by my security scans due to [CVE-2018-18928](https://nvd.nist.gov/vuln/detail/CVE-2018-18928).  This is because of the version of libicu4j-java that is installed.  After looking at this container I don't think that package is even required.  It's just installed as a consequence of installing libicu* from apt.

I'm proposing to change the pattern used to identify only the packages like "libicu\d\d" (although using the extended regular expression syntax instead of PCRE).