### PR TITLE
Fix source installation issues on R 4.3 by adding `devtools` dependencies to `install_tidyverse.sh` and update the `install2.r` script

### DIFF
--- a/scripts/bin/install2.r
+++ b/scripts/bin/install2.r
@@ -4,17 +4,20 @@
 #
 # Copyright (C) 2011 - 2014  Dirk Eddelbuettel
 # Copyright (C) 2014 - 2017  Carl Boettiger and Dirk Eddelbuettel
-# Copyright (C) 2018         Carl Boettiger, Dirk Eddelbuettel, and Brandon Bertelsen
+# Copyright (C) 2018 - 2022  Carl Boettiger, Dirk Eddelbuettel, Brandon Bertelsen, and SHIMA Tatsuya
 #
 # Released under GPL (>= 2)
 
 ## load docopt package from CRAN
 library(docopt)
 
-## configuration for docopt
-doc <- "Usage: install2.r [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [-n NCPUS] [-r REPOS...] [-m METHOD] [--error] [--skipmissing] [--] [PACKAGES ...]
+## default to first library location in .libPaths()
+libloc <- .libPaths()[1]
 
--l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]
+## configuration for docopt
+doc <- paste0("Usage: install2.r [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [-n NCPUS] [-r REPOS...] [-m METHOD] [--error] [--skipmissing] [--] [PACKAGES ...]
+
+-l --libloc LIBLOC  location in which to install [default: ", libloc, "]
 -d --deps DEPS      install suggested dependencies as well [default: NA]
 -n --ncpus NCPUS    number of processes to use for parallel install [default: getOption]
 -r --repos REPOS    repositor(y|ies) to use, or NULL for file [default: getOption]
@@ -23,7 +26,7 @@ doc <- "Usage: install2.r [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [-n NCPUS] [-r RE
 -s --skipinstalled  skip installing already installed packages [default: FALSE]
 -m --method METHOD  method to be used for downloading files [default: auto]
 -h --help           show this help text
--x --usage          show help and short example usage"
+-x --usage          show help and short example usage")
 opt <- docopt(doc)			# docopt parsing
 
 if (opt$usage) {
@@ -79,7 +82,7 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipmissing = FALSE, ski
                 grepl("download of package .* failed", e$message) ||
                 (grepl("(dependenc|package).*(is|are) not available", e$message) && !skipmissing) ||
                 grepl("installation of package.*had non-zero exit status", e$message) ||
-                grepl("installation of one or more packages failed", e$message)
+                grepl("installation of .+ packages failed", e$message)
             if (catch) {
                 e <<- e
             }

--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -26,6 +26,12 @@ apt_install \
     libssh2-1-dev \
     libxtst6 \
     libcurl4-openssl-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libfreetype6-dev \
+    libpng-dev \
+    libtiff5-dev \
+    libjpeg-dev \
     unixodbc-dev
 
 install2.r --error --skipinstalled -n "$NCPUS" \


### PR DESCRIPTION
Fix #529