### PR TITLE
Move RStudio user settings from `.rstudio/monitored/user-settings/user-settings` to `.config/rstudio/rstudio-prefs.json`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # News
 
+## 2022-09
+
+### Changes in pre-built images
+
+- RStudio Server user settings are written to `~/.config/rstudio/rstudio-prefs.json`, not `~/.rstudio/monitored/user-settings/user-settings`.
+  ([#63](https://github.com/rocker-org/rocker-versioned2/issues/63))
+
 ## 2022-07
 
 ### Changes in rocker_scripts

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -12,11 +12,15 @@ else
     addgroup "${DEFAULT_USER}" staff
 
     ## Rocker's default RStudio settings, for better reproducibility
-    mkdir -p "/home/${DEFAULT_USER}/.rstudio/monitored/user-settings"
-    cat <<EOF >"/home/${DEFAULT_USER}/.rstudio/monitored/user-settings/user-settings"
-alwaysSaveHistory="0"
-loadRData="0"
-saveAction="0"
+    mkdir -p "/home/${DEFAULT_USER}/.config/rstudio/"
+    cat <<EOF >"/home/${DEFAULT_USER}/.config/rstudio/rstudio-prefs.json"
+{
+    "save_workspace": "never",
+    "always_save_history": false,
+    "reuse_sessions_for_project_links": true,
+    "posix_terminal_shell": "bash",
+    "initial_working_directory": "/home/${DEFAULT_USER}"
+}
 EOF
     chown -R "${DEFAULT_USER}:${DEFAULT_USER}" "/home/${DEFAULT_USER}"
 fi

--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -18,8 +18,7 @@ else
     "save_workspace": "never",
     "always_save_history": false,
     "reuse_sessions_for_project_links": true,
-    "posix_terminal_shell": "bash",
-    "initial_working_directory": "/home/${DEFAULT_USER}"
+    "posix_terminal_shell": "bash"
 }
 EOF
     chown -R "${DEFAULT_USER}:${DEFAULT_USER}" "/home/${DEFAULT_USER}"


### PR DESCRIPTION
Fix #63 and related to #520

RStudio Server 1.3 or later, the configuration file is `~/.config/rstudio/rstudio-prefs.json` instead of `~/.rstudio/monitored/user-settings/user-settings`.
`~/.rstudio/monitored/user-settings/user-settings` will be deleted when RStudio is started and `~/.config/rstudio/rstudio-prefs.json` will be automatically generated.