### PR TITLE
Update groupmod for already existing group ids within the container

### DIFF
--- a/scripts/init_userconf.sh
+++ b/scripts/init_userconf.sh
@@ -70,7 +70,7 @@ fi
 
 if [ "$GROUPID" -ne 1000 ]; then ## Configure the primary GID (whether rstudio or $USER) with a different GROUPID if requested.
     echo "Modifying primary group $(id "${USER}" -g -n)"
-    groupmod -g $GROUPID "$(id "${USER}" -g -n)"
+    groupmod -o -g $GROUPID "$(id "${USER}" -g -n)"
     echo "Primary group ID is now custom_group $GROUPID"
 fi
 


### PR DESCRIPTION
If the group id already exists the group is not created. 
using the `groupmod` option   "-o, --non-unique", the group and id will be created anyways.

Host: 
   Username: fabian = 1001
   Primary Group: users = 100

Container started with `-e USERID=$(id -u fabian)` and `-e GROUPID=$(id -g fabian)` 
   Username: rstudio = 1001
   Primary Group: users =  100, rstudio = 100