### PR TITLE
[CI] More reliable RStudio version and commit date capture

### DIFF
--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -77,12 +77,8 @@ library(gert)
 .get_github_commit_date <- function(commit_url) {
   commit_date <- httr::GET(commit_url, httr::add_headers(accept = "application/vnd.github.v3+json")) |>
     httr::content() |>
-    purrr::pluck("commit", "committer", "date") |>
+    purrr::pluck("commit", "committer", "date", .default = NA) |>
     as.Date()
-
-  if (!length(commit_date)) {
-    commit_date <- NA
-  }
 
   commit_date
 }


### PR DESCRIPTION
A new RStudio was released today. (A new tag has appeared in the RStudio repository)
However, due to a bug in the detection logic on the CI, an error occurred.

The bug was caused by gert not detecting the correct tag as follows. (r-lib/gert#187)

```r
gert::git_remote_ls(remote = "https://github.com/rstudio/rstudio") |>
    dplyr::filter(stringr::str_detect(ref, "^refs/tags/v")) |>
    dplyr::arrange(dplyr::desc(ref))
#> # A tibble: 2,989 × 3
#>    ref                         symref oid                                     
#>    <chr>                       <chr>  <chr>                                   
#>  1 refs/tags/v2022.07.2+576^{} NA     e7373ef832b49b2a9b88162cfe7eac5f22c40b34
#>  2 refs/tags/v2022.07.2+576    NA     53277fece0515762daf614069fa5c11eaf1edee0
#>  3 refs/tags/v2022.07.1+554    NA     7872775ebddc40635780ca1ed238934c3345c5de
#>  4 refs/tags/v2022.07.0+548    NA     34ea3031089fa4e38738a9256d6fa6d70629c822
#>  5 refs/tags/v2022.02.4+500    NA     c0935c0fbfb2172b2f6c60cbae6c50dbc196b2eb
#>  6 refs/tags/v2022.02.3+492    NA     aaa7a713740a0767e6476f025b85cc57769e3283
#>  7 refs/tags/v2022.02.2+485    NA     8acbd38b0d4ca3c86c570cf4112a8180c48cc6fb
#>  8 refs/tags/v2022.02.1+461    NA     8aaa5d470dd82d615130dbf663ace5c7992d48e3
#>  9 refs/tags/v2022.02.0+443    NA     9f7969398b90468440a501cf065295d9050bb776
#> 10 refs/tags/v2021.09.4+403    NA     621070f02f3d2efc5e00b830f745c096c5f9d64d
#> # … with 2,979 more rows
#> # ℹ Use `print(n = ...)` to see more rows
```

The row we really wanted was a combination of tag `v2022.07.2+576` and commit `e7373ef832b49b2a9b88162cfe7eac5f22c40b34`.

I don't know why this happened, but I fixed it to ignore invalid strings and non-existent commits and updated it to get the version correctly.