### PR TITLE
Use `usermod` instead of `addgroup` for adding a group to the user

### DIFF
--- a/scripts/default_user.sh
+++ b/scripts/default_user.sh
@@ -9,7 +9,7 @@ else
     ## Need to configure non-root user for RStudio
     useradd -s /bin/bash -m "$DEFAULT_USER"
     echo "${DEFAULT_USER}:${DEFAULT_USER}" | chpasswd
-    addgroup "${DEFAULT_USER}" staff
+    usermod -a -G staff "${DEFAULT_USER}"
 
     ## Rocker's default RStudio settings, for better reproducibility
     mkdir -p "/home/${DEFAULT_USER}/.config/rstudio/"

--- a/scripts/experimental/batch_user_creation.sh
+++ b/scripts/experimental/batch_user_creation.sh
@@ -52,7 +52,7 @@ function create_user() {
         fi
         echo "${username}:${password}" | chpasswd
 
-        addgroup "${username}" staff
+        usermod -a -G staff "${username}"
 
         mkdir -p "/home/${username}/.rstudio/monitored/user-settings"
         printf "alwaysSaveHistory='0' \


### PR DESCRIPTION
Same as rocker-org/rocker#504.

Note that we have already written this in the following line.
https://github.com/rocker-org/rocker-versioned2/blob/fdc8af83524b9b87b37370a1efa3cafe214bc19c/scripts/init_userconf.sh#L66