### PR TITLE
Not to uninstall tzdata on `ubuntu:jammy`

### DIFF
--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -53,6 +53,7 @@ apt-get install -y --no-install-recommends \
     libtiff* \
     liblzma* \
     make \
+    tzdata \
     unzip \
     zip \
     zlib1g


### PR DESCRIPTION
(Maybe ) Fix #557
Explicitly installing tzdata seems to avoid tzdata removal.

Build from 4d7b801a8ae9b43d3dbfd849f866cd65cdae6ed2 https://github.com/rocker-org/rocker-versioned2/actions/runs/3374276043/jobs/5599728522#step:5:6671
This PR https://github.com/rocker-org/rocker-versioned2/pull/559/checks#step:5:6693