### PR TITLE
Update NEWS about cuda, ml images R >= 4.2.2 (`ubuntu:jammy` based)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,8 +14,8 @@
 - cuda version tags, like `rocker/cuda:cuda10.1`, `rocker/ml:4.2.1-cuda10.1` are obsolete for R 4.2.2 or later images.
   Only the R version tags like `rocker/cuda:4.2.2`, `rocker/ml-verse:latest` will remain.
   `rocker/cuda` R >= 4.2.2 corresponds to `rocker/cuda:cuda11.1` before R.4.2.1 and
-  uses `nvidia/cuda` as the base image.
-  Therefore, the image size is significantly different from `rocker/cuda` R <= 4.2.1,
+  uses `nvidia/cuda:X.Y.Z-cudnn8-devel-ubuntu22.04` as the base image.
+  Therefore, the image size is significantly larger (+6GB) from `rocker/cuda` R <= 4.2.1,
   which installed cuda on `rocker/r-ver` (based on `ubuntu:focal`).
   ([#516](https://github.com/rocker-org/rocker-versioned2/pull/516))
 - The aliases of `rocker/cuda` which was pushed to `rocker/r-ver`

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,16 @@
 
 ### Changes in pre-built images
 
-- cuda version tags, like `rocker/cuda:cuda10.1`, `rocker/cuda:4.2.1-cuda10.1` are obsolete for R 4.2.2 or later images.
-  Only the R version tags like `rocker/cuda:4.2.2`, `rocker/cuda:latest` will remain.
+- cuda version tags, like `rocker/cuda:cuda10.1`, `rocker/ml:4.2.1-cuda10.1` are obsolete for R 4.2.2 or later images.
+  Only the R version tags like `rocker/cuda:4.2.2`, `rocker/ml-verse:latest` will remain.
+  `rocker/cuda` R >= 4.2.2 corresponds to `rocker/cuda:cuda11.1` before R.4.2.1 and
+  uses `nvidia/cuda` as the base image.
+  Therefore, the image size is significantly different from `rocker/cuda` R <= 4.2.1,
+  which installed cuda on `rocker/r-ver` (based on `ubuntu:focal`).
+  ([#516](https://github.com/rocker-org/rocker-versioned2/pull/516))
 - The aliases of `rocker/cuda` which was pushed to `rocker/r-ver`
   (`rocker/r-ver:X.Y.Z-cuda10.1` and `rocker/r-ver:X.Y.Z-cuda11.1`) are obsolete.
+  ([#516](https://github.com/rocker-org/rocker-versioned2/pull/516))
 
 ## 2022-09
 


### PR DESCRIPTION
Since there was not enough description in the news (about #516), I added it.
c.f. https://github.com/rocker-org/rocker-versioned2/issues/543#issuecomment-1307707608