### PR TITLE
Add lsb-release for shiny-server

### DIFF
--- a/.github/workflows/r-build-test.yml
+++ b/.github/workflows/r-build-test.yml
@@ -65,6 +65,8 @@ jobs:
           - install_rstudio.sh
           - install_tidyverse.sh
           - install_verse.sh
+          - install_shiny_server.sh
+          - install_geospatial.sh
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx

--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -19,6 +19,7 @@ function apt_install() {
 apt_install \
     sudo \
     gdebi-core \
+    lsb-release \
     libcurl4-openssl-dev \
     libcairo2-dev \
     libxt-dev \


### PR DESCRIPTION
As a result of `lsb-release` being removed from `rocker/r-ver` in #511, it appears that `install_shiny_server.sh` is no longer functional.
We need to install `lsb-release` for shiny-server.