### PR TITLE
Allow building `rocker/rstudio:latest-daily` on linux/arm64 platform with skipping install quarto CLI

### DIFF
--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -18,6 +18,13 @@ QUARTO_VERSION=${1:-${QUARTO_VERSION:-"default"}}
 # Only amd64 build can be installed now
 ARCH=$(dpkg --print-architecture)
 
+# workaround for arm64 RStudio Daily build without quarto cli
+RSTUDIO_VERSION=${RSTUDIO_VERSION:-"stable"}
+if [ "${ARCH}" = "arm64" ] && [ "${RSTUDIO_VERSION}" = "daily" ]; then
+    echo "Skip installation of quarto cli..."
+    exit 0
+fi
+
 # a function to install apt packages only if they are not installed
 function apt_install() {
     if ! dpkg -s "$@" >/dev/null 2>&1; then


### PR DESCRIPTION
Related to #144 

Skip installation of quarto-cli to allow arm64 build of `rocker/rstudio:latest-daily`.
(workflow setup will be a following PR)