### PR TITLE
[CI] Update the reporte template to skip cuda images' notice message in package listing files

### DIFF
--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -136,20 +136,30 @@ if (!is.null(df_digest)) {
 ## Installed packages
 
 ```{r package_data}
-df_apt <- readr::read_tsv(params$apt_file, col_names = FALSE) |>
+df_apt <- params$apt_file |>
+  readr::read_lines() |>
+  stringr::str_subset(r"(\t)") |>
+  I() |>
+  read_tsv(col_names = FALSE) |>
   dplyr::select(
     package = X1,
     version = X2
   )
 
-df_r <- readr::read_table(params$r_file, skip = 1, col_names = FALSE) |>
+df_r <- params$r_file |>
+  readr::read_lines() |>
+  I() |>
+  (\(x) readr::read_table(x, col_names = FALSE, skip = stringr::str_which(x, "installed.packages()")[1]))() |>
   dplyr::select(
     package = X1,
     version = X2
   )
 
 df_pip <- tryCatch(
-  readr::read_table(params$pip_file, skip = 2, col_names = FALSE) |>
+  params$pip_file |>
+    readr::read_lines() |>
+    I() |>
+    (\(x) readr::read_table(x, col_names = FALSE, skip = stringr::str_which(x, r"(Package\s+Version)")[1] + 1))() |>
     dplyr::select(
       package = X1,
       version = X2

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -125,7 +125,10 @@ df_digest <- tryCatch(
 )
 
 if (!is.null(df_digest)) {
-  cat("### Platforms \n\n This image was created by a multi-architecture build. The digests for each platform are as follows.")
+  cat(
+    "### Platforms\n\n",
+    "This image was created by a multi-architecture build. The digests for each platform are as follows."
+  )
 
   df_digest |>
     dplyr::mutate(RepoDigests = paste0("`", RepoDigests, "`")) |>


### PR DESCRIPTION
Fix #579

- apt_file is tab separated values, but the header message has no tabs.
- r_file can be detected by the string "installed.packages()" because it has the following structure.
  ```
                    installed.packages()[, 3]
  abind                                 1.4-5
  arrow                                10.0.1
  askpass                                 1.1
  ```
- pip_file can be detected by the string "Package\s+Version" because it has the following structure.
  ```
  Package    Version
  ---------- -------
  pip        22.3.1
  setuptools 59.6.0
  wheel      0.37.1
  ```