### PR TITLE
Move (rather than link) the wgrib2 executable and delete build dir

### DIFF
--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -32,10 +32,12 @@ cd grib2
 
 ## really someone needs to learn proper packaging conventions, but whatever
 CC=gcc FC=gfortran make
-ln -s /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
+cp /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
+rm -rf /opt/grib2 
+
 
 ## Strip binary installed lybraries from RSPM
 ## https://github.com/rocker-org/rocker-versioned2/issues/340

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -38,7 +38,6 @@ cp /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
 rm -rf /var/lib/apt/lists/*
 rm -rf /opt/grib2 
 
-
 ## Strip binary installed lybraries from RSPM
 ## https://github.com/rocker-org/rocker-versioned2/issues/340
 strip /usr/local/lib/R/site-library/*/libs/*.so

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -36,7 +36,7 @@ cp /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
-rm -rf /opt/grib2 
+rm -rf /opt/grib2
 
 ## Strip binary installed lybraries from RSPM
 ## https://github.com/rocker-org/rocker-versioned2/issues/340

--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -32,7 +32,7 @@ cd grib2
 
 ## really someone needs to learn proper packaging conventions, but whatever
 CC=gcc FC=gfortran make
-cp /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
+mv /opt/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2
 
 # Clean up
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Follow up on #576 to also remove unnecessary build files as part of the wgrib2 installation that will still take place on focal images.

The build of wgrib2 creates a standalone executable. Rather than linking this file to `/usr/local/bin/wgrib2` I suggest we copy it and then remove the entire `/opt/grib2` directory. The `wgrib2` executable doesn't require any files from the build directory, and this corresponds to the authors build instructions in their `INSTALLATION`  file:

```
Try executing wgrib2

      wgrib2/wgrib2 -config

Copy wgrib2 to SOMEPLACE

      cygwin/linux/unix: cp wgrib2/wgrib2 SOMEPLACE
```

(Sorry I didn't do this in time to make the previous pull request).



