### PR TITLE
[CI] Build the `linux/arm64` platform to `rocker/rstudio:latest-daily`

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push Docker images

--- a/bakefiles/core-latest-daily.docker-bake.json
+++ b/bakefiles/core-latest-daily.docker-bake.json
@@ -25,7 +25,8 @@
         "docker.io/rocker/rstudio:latest-daily"
       ],
       "platforms": [
-        "linux/amd64"
+        "linux/amd64",
+        "linux/arm64"
       ],
       "cache-from": [
         "docker.io/rocker/rstudio:latest-daily"

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -450,6 +450,7 @@ latest_daily <- jsonlite::read_json("stacks/core-latest-daily.json")
 latest_daily$stack <- template$stack[2:4]
 latest_daily$stack[[1]]$FROM <- "rocker/r-ver:latest"
 latest_daily$stack[[1]]$ENV$RSTUDIO_VERSION <- "daily"
+latest_daily$stack[[1]]$platforms <- list("linux/amd64", "linux/arm64")
 latest_daily$stack[[2]]$FROM <- "rocker/rstudio:latest-daily"
 latest_daily$stack[[3]]$FROM <- "rocker/tidyverse:latest-daily"
 

--- a/stacks/core-latest-daily.json
+++ b/stacks/core-latest-daily.json
@@ -36,7 +36,11 @@
         "/rocker_scripts/install_quarto.sh"
       ],
       "CMD": "[\"/init\"]",
-      "EXPOSE": 8787
+      "EXPOSE": 8787,
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ]
     },
     {
       "IMAGE": "tidyverse",


### PR DESCRIPTION
Continued from #578, related to #144.

Enable the arm64 build in the daily builds to meet user demand for the arm64 version of `rocker/rstudio`.