### PR TITLE
[CI] Update for using purrr 1.0.0; Use `rlang::zap()` instead of `NULL`

### DIFF
--- a/build/make-bakejson.R
+++ b/build/make-bakejson.R
@@ -5,6 +5,7 @@ library(dplyr, warn.conflicts = FALSE)
 library(tibble)
 library(purrr, warn.conflicts = FALSE)
 library(stringr)
+library(rlang, warn.conflicts = FALSE)
 
 
 .image_full_name <- function(image_name) {
@@ -20,11 +21,11 @@ library(stringr)
 }
 
 
-.version_or_null <- function(tag) {
+.version_or_zap <- function(tag) {
   if (stringr::str_detect(tag, r"(^\d+\.\d+\.\d+$)")) {
-    return(stringr::str_c("R-", tag))
+    stringr::str_c("R-", tag)
   } else {
-    return(NULL)
+    rlang::zap()
   }
 }
 
@@ -55,7 +56,7 @@ library(stringr)
       labels = list(purrr::list_modify(
         labels,
         org.opencontainers.image.base.name = .image_full_name(base_image),
-        org.opencontainers.image.version = .version_or_null(stack_tag)
+        org.opencontainers.image.version = .version_or_zap(stack_tag)
       )),
       `cache-from` = list(if (is.null(`cache-from`)) tags[1] else `cache-from`)
     ) |>


### PR DESCRIPTION
Fix for #585, #586

The following purrr change generates incorrectly formatted docker-bake.json files.

> Removing elements with NULL in [list_modify()](https://purrr.tidyverse.org/reference/list_assign.html) and [list_merge()](https://purrr.tidyverse.org/reference/list_assign.html) is now fully deprecated.

https://purrr.tidyverse.org/news/index.html

After looking into this change, it seems that `rlang::zap()` should be used instead of `NULL` for purrr 1.0.0. (tidyverse/purrr#810)