### PR TITLE
Update to make wiki update jobs work

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -69,7 +69,7 @@ jobs:
     needs: inspect
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse:latest
+      image: rocker/tidyverse@sha256:85f108b64aaac0280d8c9ca85831ae0ce351f7afc16d23fb9859f23ef4b1cc10
     steps:
       - name: Checkout main
         uses: actions/checkout@v3

--- a/bakefiles/extra.docker-bake.json
+++ b/bakefiles/extra.docker-bake.json
@@ -30,7 +30,7 @@
       "context": "./",
       "dockerfile": "dockerfiles/geospatial-ubuntugis_4.2.2.Dockerfile",
       "labels": {
-        "org.opencontainers.image.title": "rocker/geospatial (ubuntugis)",
+        "org.opencontainers.image.title": "rocker/geospatial on ubuntugis",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.2.2",
         "org.opencontainers.image.version": "R-4.2.2"
@@ -55,7 +55,7 @@
       "context": "./",
       "dockerfile": "dockerfiles/geospatial-dev-osgeo_4.2.2.Dockerfile",
       "labels": {
-        "org.opencontainers.image.title": "rocker/geospatial (dev-osgeo)",
+        "org.opencontainers.image.title": "rocker/geospatial on dev-osgeo",
         "org.opencontainers.image.description": "Docker-based Geospatial toolkit for R, built on versioned Rocker image.",
         "org.opencontainers.image.base.name": "docker.io/rocker/verse:4.2.2",
         "org.opencontainers.image.version": "R-4.2.2"


### PR DESCRIPTION
Related to #597

It seems that the wiki update is failing due to a bug caused by two software version upgrades.

- Error parsing docker-bake.json file (docker/buildx#1586)
- `dplyr::arrange` does not work with `numeric_version` vector (tidyverse/dplyr#6680)

This PR change the string that is believed to be causing the false positives in docker-bake.json and avoids the problem by using the old dplyr.