### PR TITLE
Install cmake on install_wgrib2.sh to build wgrib2

### DIFF
--- a/scripts/install_wgrib2.sh
+++ b/scripts/install_wgrib2.sh
@@ -13,7 +13,10 @@ function apt_install() {
     fi
 }
 
-apt_install wget ca-certificates
+apt_install \
+    wget \
+    ca-certificates \
+    cmake
 
 cd /opt
 wget https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz


### PR DESCRIPTION
fix #607

The test failure in #606

```log
> [4/4] RUN /test.sh install_geospatial.sh none:
#9 759.6 grib2/wgrib2/gribtables/ncep/gribtable
#9 759.6 grib2/wgrib2/gribtables/dwd/dwd2tab.pl
#9 759.6 grib2/wgrib2/gribtables/dwd/README
#9 759.6 grib2/wgrib2/gribtables/ecmwf/README
#9 759.6 grib2/wgrib2/gribtables/ncep/README
#9 759.6 grib2/proj-4.8.0.tar.gz
#9 759.6 grib2/pywgrib2_s/README
#9 759.6 grib2/pywgrib2_s/download.sh
#9 759.6 grib2/pywgrib2_s/Documentation
#9 759.7 makefile:274: *** ERROR, Need cmake for AEC support, install cmake or set USE_AEC = 0.  Stop.
```