### PR TITLE
[CI] Using latest dplyr in CI jobs again

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -69,7 +69,7 @@ jobs:
     needs: inspect
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse@sha256:85f108b64aaac0280d8c9ca85831ae0ce351f7afc16d23fb9859f23ef4b1cc10
+      image: rocker/tidyverse:latest
     steps:
       - name: Checkout main
         uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit 0cf526e77cfcdffa7b138b10f95d72c34e96ffa3.

dplyr 1.1.1 was released and the issue of `arrange()` was fixed. (tidyverse/dplyr#6680)