### PR TITLE
reflects the upstream install2.r script updates

### DIFF
--- a/.github/workflows/r-build-test.yml
+++ b/.github/workflows/r-build-test.yml
@@ -7,7 +7,9 @@ on:
     paths:
       - scripts/install_R_source.sh
       - scripts/setup_R.sh
+      - scripts/bin/**
       - dockerfiles/r-ver_devel.Dockerfile
+      - "!**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Copied from littler 0.3.18 https://github.com/eddelbuettel/littler/tree/65485d3e7397c31184b89bbf6ef7cdaa6cd8935f

Fix #620

This version should detects new installation error massage like `installation of package ‘arrow’ failed`