### PR TITLE
Use `jupyter lab` instead of `jupyter notebook` as default command of `rocker/binder`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # News
 
+## 2023-04
+
+### Changes in pre-built images
+
+- `rocker/binder`'s default command is changed from `jupyter notebook` to `jupyter lab`.
+  ([#628](https://github.com/rocker-org/rocker-versioned2/pull/628))
+
 ## 2022-12
 
 ### Changes in pre-built images

--- a/dockerfiles/binder_4.0.0.Dockerfile
+++ b/dockerfiles/binder_4.0.0.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.1.Dockerfile
+++ b/dockerfiles/binder_4.0.1.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.2.Dockerfile
+++ b/dockerfiles/binder_4.0.2.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.3.Dockerfile
+++ b/dockerfiles/binder_4.0.3.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.4.Dockerfile
+++ b/dockerfiles/binder_4.0.4.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.5.Dockerfile
+++ b/dockerfiles/binder_4.0.5.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.0.Dockerfile
+++ b/dockerfiles/binder_4.1.0.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.1.Dockerfile
+++ b/dockerfiles/binder_4.1.1.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.2.Dockerfile
+++ b/dockerfiles/binder_4.1.2.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.3.Dockerfile
+++ b/dockerfiles/binder_4.1.3.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.0.Dockerfile
+++ b/dockerfiles/binder_4.2.0.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.1.Dockerfile
+++ b/dockerfiles/binder_4.2.1.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.2.Dockerfile
+++ b/dockerfiles/binder_4.2.2.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.3.Dockerfile
+++ b/dockerfiles/binder_4.2.3.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_devel.Dockerfile
+++ b/dockerfiles/binder_devel.Dockerfile
@@ -11,7 +11,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter notebook --ip 0.0.0.0 --no-browser"]
+CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
 
 USER ${NB_USER}
 

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -152,7 +152,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.0"

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -143,7 +143,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.1"

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -143,7 +143,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.2"

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -143,7 +143,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.3"

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -143,7 +143,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.4"

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -150,7 +150,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.5",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -165,7 +165,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.0"

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -165,7 +165,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.1"

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -165,7 +165,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.2"

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -186,7 +186,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.3",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -172,7 +172,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.0",

--- a/stacks/4.2.1.json
+++ b/stacks/4.2.1.json
@@ -172,7 +172,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.1",

--- a/stacks/4.2.2.json
+++ b/stacks/4.2.2.json
@@ -172,7 +172,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.2",

--- a/stacks/4.2.3.json
+++ b/stacks/4.2.3.json
@@ -214,7 +214,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.3",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -134,7 +134,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter notebook --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
       "EXPOSE": 8888
     },
     {


### PR DESCRIPTION
Fix #621

Jupyter notebook no longer seems to work well.