### PR TITLE
Revert "Allow building `rocker/rstudio:latest-daily` on linux/arm64 platform with skipping install quarto CLI (#578)"

### DIFF
--- a/scripts/install_quarto.sh
+++ b/scripts/install_quarto.sh
@@ -18,13 +18,6 @@ QUARTO_VERSION=${1:-${QUARTO_VERSION:-"default"}}
 # Only amd64 build can be installed now
 ARCH=$(dpkg --print-architecture)
 
-# workaround for arm64 RStudio Daily build without quarto cli
-RSTUDIO_VERSION=${RSTUDIO_VERSION:-"stable"}
-if [ "${ARCH}" = "arm64" ] && [ "${RSTUDIO_VERSION}" = "daily" ]; then
-    echo "Skip installation of quarto cli..."
-    exit 0
-fi
-
 # a function to install apt packages only if they are not installed
 function apt_install() {
     if ! dpkg -s "$@" >/dev/null 2>&1; then


### PR DESCRIPTION
The latest Quarto 1.3 release includes arm64 deb package, so the workaround is no longer needed.

This reverts commit 87ff7feb57505eff76a2a5c39e4a914231eb2b83.