### PR TITLE
enable arm64 build for `rocker/rstudio` after RStudio IDE 2023.05.0

### DIFF
--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -224,6 +224,10 @@ write_stack <- function(r_version,
   )
   template$stack[[2]]$ENV$RSTUDIO_VERSION <- rstudio_version
   template$stack[[2]]$platforms <-
+    # linux/arm64 platform version of RStudio IDE will bundle Quarto CLI after version 2023.05.1
+    # (https://github.com/rstudio/rstudio/issues/12411)
+    # We are postponing the build of the linux/arm64 version of rocker/rstudio until this version
+    # because we want to fix the version of Quarto CLI included in rocker/rstudio
     if (numeric_version(stringr::str_replace_all(rstudio_version, r"(\+)", ".")) > "2023.05.1") {
       list("linux/amd64", "linux/arm64")
     }

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -31,13 +31,12 @@ library(gert)
     NULL
   }
 
-  urls_try <- list(
+  urls_try <- tidyr::expand_grid(
     date = dates_try,
     distro_version_name = c(distro_version_name, fallback_distro),
     type = c("binary")
   ) |>
-    purrr::cross() |>
-    purrr::map_chr(purrr::lift(.make_rspm_cran_url_linux)) |>
+    purrr::pmap_chr(.make_rspm_cran_url_linux) |>
     unique()
 
   for (i in seq_along(urls_try)) {

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -224,7 +224,7 @@ write_stack <- function(r_version,
   )
   template$stack[[2]]$ENV$RSTUDIO_VERSION <- rstudio_version
   template$stack[[2]]$platforms <-
-    # linux/arm64 platform version of RStudio IDE will bundle Quarto CLI after version 2023.05.1
+    # linux/arm64 platform version of RStudio IDE will bundle Quarto CLI after version 2023.05.0
     # (https://github.com/rstudio/rstudio/issues/12411)
     # We are postponing the build of the linux/arm64 version of rocker/rstudio until this version
     # because we want to fix the version of Quarto CLI included in rocker/rstudio

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -224,6 +224,10 @@ write_stack <- function(r_version,
     r_latest
   )
   template$stack[[2]]$ENV$RSTUDIO_VERSION <- rstudio_version
+  template$stack[[2]]$platforms <-
+    if (numeric_version(stringr::str_replace_all(rstudio_version, r"(\+)", ".")) > "2023.05.1") {
+      list("linux/amd64", "linux/arm64")
+    }
 
   # rocker/tidyverse
   template$stack[[3]]$FROM <- stringr::str_c("rocker/rstudio:", r_version)

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -228,7 +228,7 @@ write_stack <- function(r_version,
     # (https://github.com/rstudio/rstudio/issues/12411)
     # We are postponing the build of the linux/arm64 version of rocker/rstudio until this version
     # because we want to fix the version of Quarto CLI included in rocker/rstudio
-    if (numeric_version(stringr::str_replace_all(rstudio_version, r"(\+)", ".")) > "2023.05.1") {
+    if (numeric_version(stringr::str_replace_all(rstudio_version, r"(\+)", ".")) > "2023.05.0") {
       list("linux/amd64", "linux/arm64")
     }
 


### PR DESCRIPTION
Close #144

Currently the linux/arm64 platform version of RStudio IDE is not bundled Quarto CLI, but bundling may begin after RStudio IDE 2023.05.0. (rstudio/rstudio#12411, rstudio/rstudio#13127)

When the Quarto CLI bundle to the RStudio IDE is started, I think we can start building arm64 version of `rocker/rstudio`.

This PR also includes a small refactoring to correspond to the recently released purrr 1.0.0. (Close #595)