### PR TITLE
Install JupyterHub as part of install_jupyter.sh

### DIFF
--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -29,7 +29,7 @@ fi
 # install python
 /rocker_scripts/install_python.sh
 
-python3 -m pip install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab
+python3 -m pip install --no-cache-dir jupyter-rsession-proxy notebook jupyterlab jupyterhub
 
 install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 


### PR DESCRIPTION
This allows using the built image with JupyterHubs for running RStudio.