### PR TITLE
fix: rstudio redirect links use focal now

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -59,6 +59,9 @@ if [ "$UBUNTU_CODENAME" = "focal" ]; then
 fi
 
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
+    if [ "$UBUNTU_CODENAME" = "bionic" ]; then
+        UBUNTU_CODENAME="focal"
+    fi
     wget "https://rstudio.org/download/latest/${RSTUDIO_VERSION}/server/${UBUNTU_CODENAME}/rstudio-server-latest-${ARCH}.deb" -O "$DOWNLOAD_FILE"
 else
     wget "https://download2.rstudio.org/server/${UBUNTU_CODENAME}/${ARCH}/rstudio-server-${RSTUDIO_VERSION/"+"/"-"}-${ARCH}.deb" -O "$DOWNLOAD_FILE" ||


### PR DESCRIPTION
See <https://dailies.rstudio.com/links/>

It seems that the links includes "bionic" is now disabled.