### PR TITLE
Build & push images once a week

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,6 +1,9 @@
 name: Build & Push Core images
 
 on:
+  schedule:
+    # Weekly, at 03:00 on Monday UTC time
+    - cron: "0 3 * * 1"
   push:
     branches:
       - "master"


### PR DESCRIPTION
Based on @cboettig's [comment](https://github.com/rocker-org/rocker-versioned2/pull/668#issuecomment-1610355217):

> I think it would be nice to ensure that the latest image is a
> relatively recent build across the board, e.g. that we're not a month
> behind pulling in patches to security-related libraries that aren't
> installed in the base image by default, (e.g. network-related libs
> like openssl / curl). This also serves to keep R packages more
> up-to-date though that's probably less important.