### PR TITLE
add hdf5/hdf4 to dev_osgeo script

### DIFF
--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -69,7 +69,9 @@ apt_install \
     libssl-dev \
     libtiff-dev \
     cmake \
-    libtiff5-dev
+    libtiff5-dev \
+    libhdf4-alt-dev \
+    libhdf5-dev
 
 ## geoparquet support
 wget https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr '[:upper:]' '[:lower:]')"/apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb


### PR DESCRIPTION
just adding HDF4Image and HDF5 drivers to the dev_osgeo script

tested with 

```bash
## respectable gdal output
gdalinfo /vsicurl/https://github.com/OSGeo/gdal/raw/master/autotest/gdrivers/data/hdf5/hdfeos_sample_swath.h5

wget https://seaice.uni-bremen.de/data/amsr2/asi_daygrid_swath/s3125/2023/aug/Antarctic3125/asi-AMSR2-s3125-20230806-v5.4.hdf

## respectable gdal output
gdalinfo asi-AMSR2-s3125-20230806-v5.4.hdf
rm asi-AMSR2-s3125-20230806-v5.4.hdf


```

thanks!  