### PR TITLE
Fix installation of littler for R devel

### DIFF
--- a/scripts/setup_R.sh
+++ b/scripts/setup_R.sh
@@ -53,6 +53,7 @@ fi
 ## Install littler
 if [ ! -x "$(command -v r)" ]; then
     BUILDDEPS="libpcre2-dev \
+        libdeflate-dev \
         liblzma-dev \
         libbz2-dev \
         zlib1g-dev \


### PR DESCRIPTION
To fix this error

```log
#13 14.92 /usr/bin/ld: cannot find -ldeflate: No such file or directory
#13 14.92 collect2: error: ld returned 1 exit status
#13 14.92 make: *** [Makevars:31: r] Error 1
#13 14.92 ERROR: compilation failed for package ‘littler’
```

https://github.com/rocker-org/rocker-versioned2/actions/runs/5892754879/job/15982750147#step:5:7206

Since 2023-08-08, daily builds of `rocler/r-ver:devel` seem to fail due to this error.