### PR TITLE
Update install_dev_osgeo.sh

### DIFF
--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -76,7 +76,6 @@ apt_install \
     libblosc-dev \
     libzstd-dev \
     liblz4-dev
-    
 ## geoparquet support
 wget https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr '[:upper:]' '[:lower:]')"/apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb
 apt_install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb

--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -75,7 +75,7 @@ apt_install \
     liblzma-dev \
     libblosc-dev \
     libzstd-dev \
-    libz4-dev
+    liblz4-dev
     
 ## geoparquet support
 wget https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr '[:upper:]' '[:lower:]')"/apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb

--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -71,8 +71,12 @@ apt_install \
     cmake \
     libtiff5-dev \
     libhdf4-alt-dev \
-    libhdf5-dev
-
+    libhdf5-dev \
+    liblzma-dev \
+    libblosc-dev \
+    libzstd-dev \
+    libz4-dev
+    
 ## geoparquet support
 wget https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr '[:upper:]' '[:lower:]')"/apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb
 apt_install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb

--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -76,6 +76,7 @@ apt_install \
     libblosc-dev \
     libzstd-dev \
     liblz4-dev
+
 ## geoparquet support
 wget https://apache.jfrog.io/artifactory/arrow/"$(lsb_release --id --short | tr '[:upper:]' '[:lower:]')"/apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb
 apt_install -y -V ./apache-arrow-apt-source-latest-"$(lsb_release --codename --short)".deb


### PR DESCRIPTION
Support for zarr format needs blosc compression.

osgeo-dev should also be sure other common compression libs are included.  

/ht @mdsumner, thanks!