### PR TITLE
Add sfarrow to install_geospatial.sh

### DIFF
--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -71,6 +71,7 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
     terra \
     tidync \
     tmap \
+    geoarrow \
     geoR \
     geosphere \
     BiocManager

--- a/scripts/install_geospatial.sh
+++ b/scripts/install_geospatial.sh
@@ -62,6 +62,7 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
     rgeos \
     rlas \
     sf \
+    sfarrow \
     sp \
     spacetime \
     spatstat \
@@ -71,7 +72,6 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" \
     terra \
     tidync \
     tmap \
-    geoarrow \
     geoR \
     geosphere \
     BiocManager


### PR DESCRIPTION
Hello, some scientists on the [NASA VEDA platform](https://www.earthdata.nasa.gov/esds/veda) using this image on RStudio wanted to read/write geoparquet files but didn't see the common libraries for interacting with geoparquet files installed. So adding them in this PR. `geoarrow` doesn't have a CRAN so let's add `sfarrow` for starters please.

* GeoParquet is an OGC standard that adds geospatial types (Point, Line, Polygon) to Parquet files
*  `sfarrow` lib can read/write parquet files with simple geometry features

