### PR TITLE
numpy in  install_dev_osgeo.sh

### DIFF
--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -134,6 +134,7 @@ fi
 ## ensure that osgeo.gdal and family get installed for python use https://github.com/OSGeo/gdal/blob/master/swig/python/README.rst
 wget https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py
+rm get-pip.py
 pip install numpy setuptools
 
 wget "$GDAL_DL_URL" -O gdal.tar.gz

--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -131,6 +131,11 @@ else
     GDAL_DL_URL="https://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz"
 fi
 
+## ensure that osgeo.gdal and family get installed for python use https://github.com/OSGeo/gdal/blob/master/swig/python/README.rst
+wget https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+pip install numpy setuptools
+
 wget "$GDAL_DL_URL" -O gdal.tar.gz
 tar -xf gdal.tar.gz
 rm gdal*tar.gz

--- a/scripts/experimental/install_dev_osgeo.sh
+++ b/scripts/experimental/install_dev_osgeo.sh
@@ -135,7 +135,7 @@ fi
 wget https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py
 rm get-pip.py
-pip install numpy setuptools
+pip install  --no-cache-dir numpy setuptools
 
 wget "$GDAL_DL_URL" -O gdal.tar.gz
 tar -xf gdal.tar.gz


### PR DESCRIPTION
I'm not entirely sure about this, and maybe setuptools is not also required - but osgeo.gdal and family require numpy, so this gets pip and installs it before building gdal

