### PR TITLE
Check if auth-minimum-user-id is already set to zero on rootless

### DIFF
--- a/scripts/init_userconf.sh
+++ b/scripts/init_userconf.sh
@@ -122,8 +122,8 @@ elif [ -z "$PASSWORD" ]; then
 fi
 
 if [ "${RUNROOTLESS}" = "true" ]; then
-    check_user_id=$(grep -F "auth-minimum-user-id" /etc/rstudio/rserver.conf | sed -e "s/^.*= *//")
-    if [[ "$check_user_id" = '0' ]]; then
+    check_user_id="$(grep -F auth-minimum-user-id /etc/rstudio/rserver.conf | sed -e 's/^.*= *//')"
+    if [[ "$check_user_id" = "0" ]]; then
         echo "root user already authorized in /etc/rstudio/rserver.conf: $check_user_id, not changed"
     elif [[ -n $check_user_id ]]; then
         echo "minimum authorised user already exists in /etc/rstudio/rserver.conf: $check_user_id"

--- a/scripts/init_userconf.sh
+++ b/scripts/init_userconf.sh
@@ -122,8 +122,10 @@ elif [ -z "$PASSWORD" ]; then
 fi
 
 if [ "${RUNROOTLESS}" = "true" ]; then
-    check_user_id=$(grep -F "auth-minimum-user-id" /etc/rstudio/rserver.conf)
-    if [[ -n $check_user_id ]]; then
+    check_user_id=$(grep -F "auth-minimum-user-id" /etc/rstudio/rserver.conf | sed -e "s/^.*= *//")
+    if [[ "$check_user_id" = '0' ]]; then
+        echo "root user already authorized in /etc/rstudio/rserver.conf: $check_user_id, not changed"
+    elif [[ -n $check_user_id ]]; then
         echo "minimum authorised user already exists in /etc/rstudio/rserver.conf: $check_user_id"
         echo "RUNROOTLESS=true mode requires setting minimum authorised user to 0. Exiting"
         exit 1


### PR DESCRIPTION
Closes #653

The patch does some minimal grep/sed parsing of `/etc/rstudio/rserver.conf`, which may not be super robust, but good and simple enough for our use case
