### PR TITLE
binder: Install packages required for Jupyter to PDF convert

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 ### Changes in pre-built images
 
 - `rocker/binder` now includes necessary LaTeX packages to allow Jupyter Notebooks to be converted to PDF. ([#714](https://github.com/rocker-org/rocker-versioned2/pull/714))
+  - `install_jupyter.sh` will now install TexLive if it is not installed, and add
+     additional LaTeX packages needed for Jupyter PDF conversion. This will increase
+     the size of the final image in cases `install_jupyter.sh` is called.
 
 ## 2023-04
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # News
 
+## 2023-10
+
+### Changes in pre-built images
+
+- `rocker/binder` now includes necessary LaTeX packages to allow Jupyter Notebooks to be converted to PDF. ([#714](https://github.com/rocker-org/rocker-versioned2/pull/714))
+
 ## 2023-04
 
 ### Changes in pre-built images

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,12 @@
 ### Changes in pre-built images
 
 - `rocker/binder` now includes necessary LaTeX packages to allow Jupyter Notebooks to be converted to PDF. ([#714](https://github.com/rocker-org/rocker-versioned2/pull/714))
-  - `install_jupyter.sh` will now install TexLive if it is not installed, and add
-     additional LaTeX packages needed for Jupyter PDF conversion. This will increase
-     the build time and size of the final image in cases `install_jupyter.sh` is called.
+
+### Changes in rocker_scripts
+
+- `install_jupyter.sh` will now install TexLive if it is not installed, and add
+  additional LaTeX packages needed for Jupyter PDF conversion. This will increase
+  the build time and size of the final image in cases `install_jupyter.sh` is called.
 
 ## 2023-04
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - `rocker/binder` now includes necessary LaTeX packages to allow Jupyter Notebooks to be converted to PDF. ([#714](https://github.com/rocker-org/rocker-versioned2/pull/714))
   - `install_jupyter.sh` will now install TexLive if it is not installed, and add
      additional LaTeX packages needed for Jupyter PDF conversion. This will increase
-     the size of the final image in cases `install_jupyter.sh` is called.
+     the build time and size of the final image in cases `install_jupyter.sh` is called.
 
 ## 2023-04
 

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -36,9 +36,12 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
-# shellcheck source=install_texlive.sh
 # Install texlive if it has not already been installed
-which tlmgr || source /rocker_scripts/install_texlive.sh
+if ! command -v tlmgr; then
+    # shellcheck source=install_texlive.sh
+    source /rocker_scripts/install_texlive.sh
+fi
+
 # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
 # Sourced from https://github.com/jupyter/nbconvert/issues/1328
 tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -36,7 +36,8 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
-## Install texlive if it has not already been installed
+# shellcheck source=install_texlive.sh
+# Install texlive if it has not already been installed
 which tlmgr || source /rocker_scripts/install_texlive.sh
 # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
 # Sourced from https://github.com/jupyter/nbconvert/issues/1328

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -37,7 +37,7 @@ R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
 ## Install texlive if it has not already been installed
-which tlmgr || /rocker_scripts/install_texlive.sh
+which tlmgr || source /rocker_scripts/install_texlive.sh
 # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
 # Sourced from https://github.com/jupyter/nbconvert/issues/1328
 tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -38,7 +38,7 @@ R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
 # Install texlive if it has not already been installed
 if ! command -v tlmgr; then
-    # shellcheck source=scripts/install_texlive.sh
+    # shellcheck source=/dev/null
     source /rocker_scripts/install_texlive.sh
 fi
 

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -36,6 +36,8 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
+## Install texlive
+/rocker_scripts/install_texlive.sh
 # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
 # Sourced from https://github.com/jupyter/nbconvert/issues/1328
 tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -36,8 +36,8 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
-## Install texlive
-/rocker_scripts/install_texlive.sh
+## Install texlive if it has not already been installed
+which tlmgr || /rocker_scripts/install_texlive.sh
 # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
 # Sourced from https://github.com/jupyter/nbconvert/issues/1328
 tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -38,7 +38,7 @@ R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
 # Install texlive if it has not already been installed
 if ! command -v tlmgr; then
-    # shellcheck source=install_texlive.sh
+    # shellcheck source=scripts/install_texlive.sh
     source /rocker_scripts/install_texlive.sh
 fi
 

--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -36,6 +36,13 @@ install2.r --error --skipmissing --skipinstalled -n "$NCPUS" remotes
 R --quiet -e 'remotes::install_github("IRkernel/IRkernel@*release")'
 R --quiet -e 'IRkernel::installspec(user = FALSE)'
 
+# Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
+# Sourced from https://github.com/jupyter/nbconvert/issues/1328
+tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \
+    pdfcol pgf rsfs tcolorbox titling trimspaces ucs ulem upquote \
+    ltxcmds infwarerr iftex kvoptions kvsetkeys float geometry amsmath fontspec \
+    unicode-math fancyvrb grffile hyperref booktabs soul ec
+
 # Clean up
 rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/downloaded_packages


### PR DESCRIPTION
Per https://github.com/jupyter/nbconvert/issues/1328, these are the packages needed for Jupyter to be able to convert to PDF. Without it, you get unfriendly errors like [this] (https://github.com/2i2c-org/infrastructure/issues/3188#issuecomment-1755969247).

Given that the binder image includes jupyter, and texlive is included in the base, I hope it would be reasonable for the binder image to include enough texlive packages for PDF conversion to work. Otherwise, it works in RStudio but not in Jupyter.