### PR TITLE
[CI] Fix and refactor the script to auto update definition files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # News
 
+## 2023-11
+
+### Changes in pre-built images
+
+- Switch the base URL of CRAN mirrors (P3M, formerly RSPM) from `https://packagemanager.posit.co/cran`
+  to `https://p3m.dev/cran` ([#722](https://github.com/rocker-org/rocker-versioned2/pull/722))
+
 ## 2023-10
 
 ### Changes in pre-built images

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -112,7 +112,9 @@ library(gert)
 .cuda_baseimage_tag <- function(ubuntu_series, other_variants = "11.8.0-cudnn8-devel") {
   ubuntu_version <- dplyr::case_when(
     ubuntu_series == "focal" ~ "20.04",
-    ubuntu_series == "jammy" ~ "22.04"
+    ubuntu_series == "jammy" ~ "22.04",
+    ubuntu_series == "noble" ~ "24.04",
+    .default = "unknown"
   )
 
   image_tag <- glue::glue("nvidia/cuda:{other_variants}-ubuntu{ubuntu_version}", .na = NULL)

--- a/build/make-stacks.R
+++ b/build/make-stacks.R
@@ -51,7 +51,7 @@ library(gert)
 }
 
 .make_rspm_cran_url_linux <- function(date, distro_version_name, type = "source") {
-  base_url <- "https://packagemanager.posit.co/cran"
+  base_url <- "https://p3m.dev/cran"
   .url <- dplyr::case_when(
     type == "source" & is.na(date) ~ glue::glue("{base_url}/latest"),
     type == "binary" & is.na(date) ~ glue::glue("{base_url}/__linux__/{distro_version_name}/latest"),

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -27,7 +27,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2020-06-04",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2020-06-04",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -18,7 +18,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2020-06-18",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2020-06-18",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -18,7 +18,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2020-10-09",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2020-10-09",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -18,7 +18,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-02-11",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-02-11",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -18,7 +18,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-03-30",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-03-30",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -18,7 +18,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-05-17",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-05-17",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-08-09",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-08-09",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -271,7 +271,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-08-09",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-08-09",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-10-29",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-10-29",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -271,7 +271,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2021-10-29",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2021-10-29",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-03-09",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-03-09",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -271,7 +271,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-03-09",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-03-09",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-04-21",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-04-21",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -316,7 +316,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-04-21",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-04-21",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-06-22",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-06-22",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -286,7 +286,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-06-22",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-06-22",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.2.1.json
+++ b/stacks/4.2.1.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-10-28",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-10-28",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -286,7 +286,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/focal/2022-10-28",
+        "CRAN": "https://p3m.dev/cran/__linux__/focal/2022-10-28",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.2.2.json
+++ b/stacks/4.2.2.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-03-14",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -202,7 +202,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-14",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-03-14",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.2.3.json
+++ b/stacks/4.2.3.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-04-20",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-04-20",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -220,7 +220,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-04-20",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-04-20",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.3.0.json
+++ b/stacks/4.3.0.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-06-15",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-06-15",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -206,7 +206,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-06-15",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-06-15",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.3.1.json
+++ b/stacks/4.3.1.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-10-30",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -206,7 +206,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/2023-10-30",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",

--- a/stacks/4.3.2.json
+++ b/stacks/4.3.2.json
@@ -32,7 +32,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/latest",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",
@@ -260,7 +260,7 @@
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
       "ENV_after_a_script": {
-        "CRAN": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+        "CRAN": "https://p3m.dev/cran/__linux__/jammy/latest",
         "LANG": "en_US.UTF-8"
       },
       "COPY": "scripts /rocker_scripts",


### PR DESCRIPTION
- Fix a process that started to fail due to the announcement of Ubuntu 24.04.
- Use short URLs `p3m.dev/cran` for Posit Public Package Manager, which have recently come into use.