### PR TITLE
Add tlmgr packages needed for quarto to knit to PDF

### DIFF
--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -56,6 +56,7 @@ tlmgr install \
     bibtex \
     bigintcalc \
     bitset \
+    bookmark \
     context \
     ec \
     epstopdf-pkg \
@@ -70,6 +71,7 @@ tlmgr install \
     inconsolata \
     infwarerr \
     intcalc \
+    koma-script \
     kvdefinekeys \
     kvoptions \
     kvsetkeys \
@@ -77,6 +79,7 @@ tlmgr install \
     listings \
     ltxcmds \
     makeindex \
+    mdwtools \
     metafont \
     mfware \
     parskip \
@@ -87,6 +90,7 @@ tlmgr install \
     rerunfilecheck \
     stringenc \
     tex \
+    tikzfill \
     tools \
     uniquecounter \
     url \


### PR DESCRIPTION
Follow-up to https://github.com/rocker-org/rocker-versioned2/pull/721, adding tlmgr packages that *quarto* seems to need to knit to PDF. Without these, it takes a minute or more (depending on network) for first knit to happen apparently.

Reported to me by users from University of Toronto