### PR TITLE
fix: add libxt6

### DIFF
--- a/scripts/install_R_source.sh
+++ b/scripts/install_R_source.sh
@@ -52,6 +52,7 @@ apt-get install -y --no-install-recommends \
     "libreadline${READLINE_VERSION}" \
     libtiff* \
     liblzma* \
+    libxt6 \
     make \
     tzdata \
     unzip \


### PR DESCRIPTION
This adds libxt6 and fixes #731 (and https://github.com/rocker-org/devcontainer-templates/issues/28).
According to my tests, it adds roughly 0.67 MB to the r-ver image. 