### PR TITLE
install texlive conditionally

### DIFF
--- a/scripts/install_jupyter.sh
+++ b/scripts/install_jupyter.sh
@@ -43,12 +43,15 @@ if ! command -v tlmgr; then
     source /rocker_scripts/install_texlive.sh
 fi
 
-# Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
-# Sourced from https://github.com/jupyter/nbconvert/issues/1328
-tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \
-    pdfcol pgf rsfs tcolorbox titling trimspaces ucs ulem upquote \
-    ltxcmds infwarerr iftex kvoptions kvsetkeys float geometry amsmath fontspec \
-    unicode-math fancyvrb grffile hyperref booktabs soul ec
+# If we are using official Ubuntu binaries, we do not need tex packages installed manually with tlmgr
+if [[ ! -x "/usr/bin/latex" ]]; then
+    # Install tex packages needed for Jupyter's nbconvert to work correctly & convert to PDF
+    # Sourced from https://github.com/jupyter/nbconvert/issues/1328
+    tlmgr install adjustbox caption collectbox enumitem environ eurosym etoolbox jknapltx parskip \
+        pdfcol pgf rsfs tcolorbox titling trimspaces ucs ulem upquote \
+        ltxcmds infwarerr iftex kvoptions kvsetkeys float geometry amsmath fontspec \
+        unicode-math fancyvrb grffile hyperref booktabs soul ec
+fi
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if [[ -x "/usr/bin/latex" ]]; then
+    echo "texlive already installed"
+    exit 0
+fi
+
 set -e
 
 CTAN_REPO=${1:-${CTAN_REPO:-"https://mirror.ctan.org/systems/texlive/tlnet"}}

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
+set -e
 
 if [[ -x "/usr/bin/latex" ]]; then
     echo "texlive already installed"
     exit 0
 fi
-
-set -e
 
 CTAN_REPO=${1:-${CTAN_REPO:-"https://mirror.ctan.org/systems/texlive/tlnet"}}
 

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -74,9 +74,13 @@ apt-get remove -y systemd
 apt-get -y autoremove
 
 ## Add LaTeX, rticles and bookdown support
-wget "https://travis-bin.yihui.name/texlive-local.deb"
-dpkg -i texlive-local.deb
-rm texlive-local.deb
+
+## tinytex recommends a dummy texlive if using tlmgr manually
+if [[ ! -x "/usr/bin/latex" ]]; then
+    wget "https://travis-bin.yihui.name/texlive-local.deb"
+    dpkg -i texlive-local.deb
+    rm texlive-local.deb
+fi
 
 ## Install texlive
 /rocker_scripts/install_texlive.sh

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -74,7 +74,6 @@ apt-get remove -y systemd
 apt-get -y autoremove
 
 ## Add LaTeX, rticles and bookdown support
-
 ## tinytex recommends a dummy texlive if using tlmgr manually
 if [[ ! -x "/usr/bin/latex" ]]; then
     wget "https://travis-bin.yihui.name/texlive-local.deb"

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -17,8 +17,7 @@
     "install_python.sh",
     "install_jupyter.sh",
     "install_julia.sh",
-    "install_cuda-10.1.sh",
-    "install_texlive.sh"
+    "install_cuda-10.1.sh"
   ],
   "script_arg": [
     "none"
@@ -69,7 +68,7 @@
     {
       "base_image": "rocker/cuda",
       "tag": "latest",
-      "script_name": "install_texlive.sh",
+      "script_name": "install_verse.sh",
       "script_arg": "none"
     },
     {

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -68,7 +68,7 @@
     },
     {
       "base_image": "rocker/cuda",
-      "tag": "cuda11.1",
+      "tag": "latest",
       "script_name": "install_texlive.sh",
       "script_arg": "none"
     },

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -17,7 +17,8 @@
     "install_python.sh",
     "install_jupyter.sh",
     "install_julia.sh",
-    "install_cuda-10.1.sh"
+    "install_cuda-10.1.sh",
+    "install_texlive.sh"
   ],
   "script_arg": [
     "none"
@@ -63,6 +64,12 @@
       "base_image": "rocker/r-ver",
       "tag": "4.0.4",
       "script_name": "install_tensorflow.sh",
+      "script_arg": "none"
+    },
+    {
+      "base_image": "rocker/cuda",
+      "tag": "cuda11.1",
+      "script_name": "install_texlive.sh",
       "script_arg": "none"
     },
     {


### PR DESCRIPTION
@eitsupi my apologies, I didn't realize my local test was pulling the upstream image.  The tex issue is specific to the changes in #743 -- specifically, the official ubuntu repo texlive binaries are installed and purged in the BUILDDEPS list.  By not purging builddeps, we had conflicting versions of texlive.  

This PR modifies the `install_texlive.sh` to not do the manual install of tlmgr from CPAN if the texlive has already be installed by apt-get (i.e. `/usr/bin/latex` already exists).  I believe it should resolve the issue.  