### PR TITLE
include core ML libraries on the ML image

### DIFF
--- a/dockerfiles/cuda_4.3.1.Dockerfile
+++ b/dockerfiles/cuda_4.3.1.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/dockerfiles/cuda_4.3.2.Dockerfile
+++ b/dockerfiles/cuda_4.3.2.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/dockerfiles/cuda_devel.Dockerfile
+++ b/dockerfiles/cuda_devel.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/dockerfiles/ml_4.3.1.Dockerfile
+++ b/dockerfiles/ml_4.3.1.Dockerfile
@@ -15,6 +15,7 @@ RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
+RUN /rocker_scripts/install_ml-cuda.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/ml_4.3.2.Dockerfile
+++ b/dockerfiles/ml_4.3.2.Dockerfile
@@ -15,6 +15,7 @@ RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
+RUN /rocker_scripts/install_ml-cuda.sh
 
 EXPOSE 8787
 

--- a/dockerfiles/ml_devel.Dockerfile
+++ b/dockerfiles/ml_devel.Dockerfile
@@ -15,6 +15,7 @@ RUN /rocker_scripts/install_rstudio.sh
 RUN /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_quarto.sh
 RUN /rocker_scripts/install_tidyverse.sh
+RUN /rocker_scripts/install_ml-cuda.sh
 
 EXPOSE 8787
 

--- a/scripts/install_ml-cuda.sh
+++ b/scripts/install_ml-cuda.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# always set this for scripts but don't declare as ENV..
+export DEBIAN_FRONTEND=noninteractive
+
+
+# a function to install apt packages only if they are not installed
+function apt_install() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt-get -qq update
+        fi
+        apt-get install -y --no-install-recommends "$@"
+    fi
+}
+
+apt_install pciutils
+
+python3 -m pip install --no-cache-dir torch tensorflow[and-cuda] keras
+
+install2.r --error --skipmissing --skipinstalled torch tensorflow keras 
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+rm -r /tmp/downloaded_packages
+
+

--- a/scripts/install_ml-cuda.sh
+++ b/scripts/install_ml-cuda.sh
@@ -3,7 +3,6 @@
 # always set this for scripts but don't declare as ENV..
 export DEBIAN_FRONTEND=noninteractive
 
-
 # a function to install apt packages only if they are not installed
 function apt_install() {
     if ! dpkg -s "$@" >/dev/null 2>&1; then
@@ -18,10 +17,8 @@ apt_install pciutils
 
 python3 -m pip install --no-cache-dir torch tensorflow[and-cuda] keras
 
-install2.r --error --skipmissing --skipinstalled torch tensorflow keras 
+install2.r --error --skipmissing --skipinstalled torch tensorflow keras
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
 rm -r /tmp/downloaded_packages
-
-

--- a/scripts/install_ml-cuda.sh
+++ b/scripts/install_ml-cuda.sh
@@ -15,7 +15,7 @@ function apt_install() {
 
 apt_install pciutils
 
-python3 -m pip install --no-cache-dir torch tensorflow[and-cuda] keras
+python3 -m pip install --no-cache-dir "torch" "tensorflow[and-cuda]" "keras"
 
 install2.r --error --skipmissing --skipinstalled torch tensorflow keras
 

--- a/stacks/4.3.1.json
+++ b/stacks/4.3.1.json
@@ -205,7 +205,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
@@ -248,7 +248,8 @@
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
         "/rocker_scripts/install_quarto.sh",
-        "/rocker_scripts/install_tidyverse.sh"
+        "/rocker_scripts/install_tidyverse.sh",
+        "/rocker_scripts/install_ml-cuda.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787

--- a/stacks/4.3.2.json
+++ b/stacks/4.3.2.json
@@ -259,7 +259,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
@@ -308,7 +308,8 @@
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
         "/rocker_scripts/install_quarto.sh",
-        "/rocker_scripts/install_tidyverse.sh"
+        "/rocker_scripts/install_tidyverse.sh",
+        "/rocker_scripts/install_ml-cuda.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -158,7 +158,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",
@@ -194,7 +194,8 @@
         "/rocker_scripts/install_rstudio.sh",
         "/rocker_scripts/install_pandoc.sh",
         "/rocker_scripts/install_quarto.sh",
-        "/rocker_scripts/install_tidyverse.sh"
+        "/rocker_scripts/install_tidyverse.sh",
+        "/rocker_scripts/install_ml-cuda.sh"
       ],
       "CMD": "[\"/init\"]",
       "EXPOSE": 8787

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -68,7 +68,7 @@
     {
       "base_image": "rocker/cuda",
       "tag": "latest",
-      "script_name": "install_verse.sh",
+      "script_name": "install_jupyter.sh",
       "script_arg": "none"
     },
     {


### PR DESCRIPTION
Now that I think we finally have a nice way to provide a default python environment without locking users into that virtualenv, I think we can provide out-of-the-box support for the main ml frameworks one would probably expect to have in such a large and GPU-focused image. 

This adds support for `tensorflow`, `keras`, and `torch` out-of-the-box, with both the corresponding R and python libraries.  