### PR TITLE
hotfix on path order

### DIFF
--- a/dockerfiles/cuda_4.3.1.Dockerfile
+++ b/dockerfiles/cuda_4.3.1.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/dockerfiles/cuda_4.3.2.Dockerfile
+++ b/dockerfiles/cuda_4.3.2.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/dockerfiles/cuda_devel.Dockerfile
+++ b/dockerfiles/cuda_devel.Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV RETICULATE_AUTOCONFIGURE=0
 ENV PURGE_BUILDDEPS=false
 ENV VIRTUAL_ENV=/opt/venv
-ENV PATH=${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin
 
 COPY scripts/install_R_source.sh /rocker_scripts/install_R_source.sh
 

--- a/stacks/4.3.1.json
+++ b/stacks/4.3.1.json
@@ -205,7 +205,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",

--- a/stacks/4.3.2.json
+++ b/stacks/4.3.2.json
@@ -259,7 +259,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -158,7 +158,7 @@
         "RETICULATE_AUTOCONFIGURE": "0",
         "PURGE_BUILDDEPS": "false",
         "VIRTUAL_ENV": "/opt/venv",
-        "PATH": "${PATH}:${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin"
+        "PATH": "${VIRTUAL_ENV}/bin:${PATH}:${CUDA_HOME}/bin"
       },
       "COPY_a_script": "scripts/install_R_source.sh /rocker_scripts/install_R_source.sh",
       "RUN_a_script": "/rocker_scripts/install_R_source.sh",


### PR DESCRIPTION
some scripts put `/opt/venv/bin` at the end of path, should be at the start (to take precedence over the base python which shouldn't be used for pip installs etc).  