### PR TITLE
Ensure SIGTERM leads to graceful termination in rocker/binder

### DIFF
--- a/dockerfiles/binder_4.0.0.Dockerfile
+++ b/dockerfiles/binder_4.0.0.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.1.Dockerfile
+++ b/dockerfiles/binder_4.0.1.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.2.Dockerfile
+++ b/dockerfiles/binder_4.0.2.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.3.Dockerfile
+++ b/dockerfiles/binder_4.0.3.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.4.Dockerfile
+++ b/dockerfiles/binder_4.0.4.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.0.5.Dockerfile
+++ b/dockerfiles/binder_4.0.5.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.0.Dockerfile
+++ b/dockerfiles/binder_4.1.0.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.1.Dockerfile
+++ b/dockerfiles/binder_4.1.1.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.2.Dockerfile
+++ b/dockerfiles/binder_4.1.2.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.1.3.Dockerfile
+++ b/dockerfiles/binder_4.1.3.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.0.Dockerfile
+++ b/dockerfiles/binder_4.2.0.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.1.Dockerfile
+++ b/dockerfiles/binder_4.2.1.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.2.Dockerfile
+++ b/dockerfiles/binder_4.2.2.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.2.3.Dockerfile
+++ b/dockerfiles/binder_4.2.3.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.3.0.Dockerfile
+++ b/dockerfiles/binder_4.3.0.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.3.1.Dockerfile
+++ b/dockerfiles/binder_4.3.1.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.3.2.Dockerfile
+++ b/dockerfiles/binder_4.3.2.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_4.3.3.Dockerfile
+++ b/dockerfiles/binder_4.3.3.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/dockerfiles/binder_devel.Dockerfile
+++ b/dockerfiles/binder_devel.Dockerfile
@@ -13,7 +13,7 @@ RUN /rocker_scripts/install_jupyter.sh
 
 EXPOSE 8888
 
-CMD ["/bin/sh", "-c", "jupyter lab --ip 0.0.0.0 --no-browser"]
+CMD ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser"]
 
 USER ${NB_USER}
 

--- a/stacks/4.0.0.json
+++ b/stacks/4.0.0.json
@@ -154,7 +154,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.0"

--- a/stacks/4.0.1.json
+++ b/stacks/4.0.1.json
@@ -145,7 +145,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.1"

--- a/stacks/4.0.2.json
+++ b/stacks/4.0.2.json
@@ -145,7 +145,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.2"

--- a/stacks/4.0.3.json
+++ b/stacks/4.0.3.json
@@ -145,7 +145,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.3"

--- a/stacks/4.0.4.json
+++ b/stacks/4.0.4.json
@@ -145,7 +145,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.4"

--- a/stacks/4.0.5.json
+++ b/stacks/4.0.5.json
@@ -152,7 +152,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.0.5",

--- a/stacks/4.1.0.json
+++ b/stacks/4.1.0.json
@@ -167,7 +167,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.0"

--- a/stacks/4.1.1.json
+++ b/stacks/4.1.1.json
@@ -167,7 +167,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.1"

--- a/stacks/4.1.2.json
+++ b/stacks/4.1.2.json
@@ -167,7 +167,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.2"

--- a/stacks/4.1.3.json
+++ b/stacks/4.1.3.json
@@ -188,7 +188,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.1.3",

--- a/stacks/4.2.0.json
+++ b/stacks/4.2.0.json
@@ -174,7 +174,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.0",

--- a/stacks/4.2.1.json
+++ b/stacks/4.2.1.json
@@ -174,7 +174,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.1",

--- a/stacks/4.2.2.json
+++ b/stacks/4.2.2.json
@@ -174,7 +174,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.2",

--- a/stacks/4.2.3.json
+++ b/stacks/4.2.3.json
@@ -188,7 +188,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.2.3",

--- a/stacks/4.3.0.json
+++ b/stacks/4.3.0.json
@@ -178,7 +178,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.3.0",

--- a/stacks/4.3.1.json
+++ b/stacks/4.3.1.json
@@ -178,7 +178,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.3.1",

--- a/stacks/4.3.2.json
+++ b/stacks/4.3.2.json
@@ -178,7 +178,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.3.2",

--- a/stacks/4.3.3.json
+++ b/stacks/4.3.3.json
@@ -220,7 +220,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888,
       "tags": [
         "docker.io/rocker/binder:4.3.3",

--- a/stacks/devel.json
+++ b/stacks/devel.json
@@ -136,7 +136,7 @@
       ],
       "USER": "${NB_USER}",
       "WORKDIR": "/home/${NB_USER}",
-      "CMD": "[\"/bin/sh\", \"-c\", \"jupyter lab --ip 0.0.0.0 --no-browser\"]",
+      "CMD": "[\"jupyter\", \"lab\", \"--ip\", \"0.0.0.0\", \"--no-browser\"]",
       "EXPOSE": 8888
     },
     {


### PR DESCRIPTION
Fixes #771, not by introducing `tini`, but by ensuring we don't let `sh` be the init process which in turn runs `jupyter lab` without propegating SIGTERM to it.

There may be a point to introduce `tini` or similar, but from the SIGTERM perspective, this does the trick as well.

This PR is modelled on for example https://github.com/rocker-org/rocker-versioned2/pull/740/files where I see that all Dockerfiles are updated along with a repsective .json file.