### PR TITLE
fix: use gdebi-core to install RStudio

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -25,19 +25,8 @@ function apt_install() {
 
 apt_install \
     ca-certificates \
-    lsb-release \
-    file \
+    gdebi-core \
     git \
-    libapparmor1 \
-    libclang-dev \
-    libcurl4-openssl-dev \
-    libedit2 \
-    libobjc4 \
-    libssl-dev \
-    libpq5 \
-    psmisc \
-    procps \
-    python-setuptools \
     pwgen \
     sudo \
     wget
@@ -68,7 +57,7 @@ else
         wget "https://s3.amazonaws.com/rstudio-ide-build/server/${UBUNTU_CODENAME}/${ARCH}/rstudio-server-${RSTUDIO_VERSION/"+"/"-"}-${ARCH}.deb" -O "$DOWNLOAD_FILE"
 fi
 
-dpkg -i "$DOWNLOAD_FILE"
+gdebi --non-interactive "$DOWNLOAD_FILE"
 rm "$DOWNLOAD_FILE"
 
 ln -fs /usr/lib/rstudio-server/bin/rstudio-server /usr/local/bin
@@ -83,7 +72,7 @@ mkdir -p /etc/R
 ## Make RStudio compatible with case when R is built from source
 ## (and thus is at /usr/local/bin/R), because RStudio doesn't obey
 ## path if a user apt-get installs a package
-R_BIN=$(which R)
+R_BIN="$(which R)"
 echo "rsession-which-r=${R_BIN}" >/etc/rstudio/rserver.conf
 ## use more robust file locking to avoid errors when using shared volumes:
 echo "lock-type=advisory" >/etc/rstudio/file-locks

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -27,6 +27,7 @@ apt_install \
     ca-certificates \
     gdebi-core \
     git \
+    libssl-dev \
     pwgen \
     sudo \
     wget

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -51,6 +51,11 @@ if [ "$UBUNTU_CODENAME" = "focal" ]; then
     UBUNTU_CODENAME="bionic"
 fi
 
+# TODO: remove this workaround for Ubuntu 24.04
+if [ "$UBUNTU_CODENAME" = "noble" ]; then
+    UBUNTU_CODENAME="jammy"
+fi
+
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
     if [ "$UBUNTU_CODENAME" = "bionic" ]; then
         UBUNTU_CODENAME="focal"

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -29,6 +29,7 @@ apt_install \
     git \
     libclang-dev \
     libssl-dev \
+    lsb-release \
     psmisc \
     pwgen \
     sudo \

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -27,6 +27,7 @@ apt_install \
     ca-certificates \
     gdebi-core \
     git \
+    libclang-dev \
     libssl-dev \
     psmisc \
     pwgen \

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -28,6 +28,7 @@ apt_install \
     gdebi-core \
     git \
     libssl-dev \
+    psmisc \
     pwgen \
     sudo \
     wget

--- a/tests/rocker_scripts/matrix.json
+++ b/tests/rocker_scripts/matrix.json
@@ -3,7 +3,7 @@
     "rocker/r-ver"
   ],
   "tag": [
-    "4.0.0",
+    "4.3.0",
     "latest"
   ],
   "script_name": [
@@ -23,12 +23,6 @@
     "none"
   ],
   "include": [
-    {
-      "base_image": "rocker/r-ver",
-      "tag": "4.0.0",
-      "script_name": "install_rstudio.sh",
-      "script_arg": "1.3.959"
-    },
     {
       "base_image": "rocker/r-ver",
       "tag": "devel",
@@ -54,27 +48,9 @@
       "script_arg": "prerelease"
     },
     {
-      "base_image": "rocker/r-ver",
-      "tag": "4.0.5",
-      "script_name": "install_cuda-11.1.sh",
-      "script_arg": "none"
-    },
-    {
-      "base_image": "rocker/r-ver",
-      "tag": "4.0.4",
-      "script_name": "install_tensorflow.sh",
-      "script_arg": "none"
-    },
-    {
       "base_image": "rocker/cuda",
       "tag": "latest",
       "script_name": "install_verse.sh",
-      "script_arg": "none"
-    },
-    {
-      "base_image": "rocker/cuda",
-      "tag": "cuda11.1",
-      "script_name": "config_R_cuda.sh",
       "script_arg": "none"
     },
     {


### PR DESCRIPTION
python-setuptools is no longer available on Ubuntu 24.04.