### PR TITLE
ci: need more space for this workflow

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -56,6 +56,9 @@ jobs:
       matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4.1.4
+      - name: Clean up
+        run: |
+          docker image prune --all --force
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
https://github.com/rocker-org/rocker-versioned2/actions/runs/9031858606/job/24818930814#step:7:6417

```log
#60 exporting to image
#60 exporting layers
#60 exporting layers 93.4s done
#60 ERROR: mount callback failed on /tmp/containerd-mount3300003192: mount callback failed on /tmp/containerd-mount2529497484: failed to write compressed diff: failed to create diff tar stream: failed to copy: write /var/lib/buildkit/runc-overlayfs/content/ingest/693b8df03444e992ae900c05824dc3edea63723ab0d15dec82a99a5f9071aeb4/data: no space left on device
```