### PR TITLE
Fix Rstudio installation on devel images

### DIFF
--- a/build/args/devel.json
+++ b/build/args/devel.json
@@ -5,7 +5,7 @@
   "ubuntu_series": "latest",
   "ubuntu_version": null,
   "cran": "https://cloud.r-project.org",
-  "rstudio_version": "2024.04.2+764",
+  "rstudio_version": "latest",
   "ctan": "https://mirror.ctan.org/systems/texlive/tlnet",
   "r_major_latest": null,
   "r_minor_latest": null

--- a/dockerfiles/geospatial_devel.Dockerfile
+++ b/dockerfiles/geospatial_devel.Dockerfile
@@ -18,7 +18,7 @@ COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/ml-verse_devel.Dockerfile
+++ b/dockerfiles/ml-verse_devel.Dockerfile
@@ -34,7 +34,7 @@ COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/ml_devel.Dockerfile
+++ b/dockerfiles/ml_devel.Dockerfile
@@ -34,7 +34,7 @@ COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/rstudio_devel.Dockerfile
+++ b/dockerfiles/rstudio_devel.Dockerfile
@@ -15,7 +15,7 @@ COPY scripts/setup_R.sh /rocker_scripts/setup_R.sh
 RUN /rocker_scripts/setup_R.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/tidyverse_devel.Dockerfile
+++ b/dockerfiles/tidyverse_devel.Dockerfile
@@ -18,7 +18,7 @@ COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/dockerfiles/verse_devel.Dockerfile
+++ b/dockerfiles/verse_devel.Dockerfile
@@ -18,7 +18,7 @@ COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 ENV S6_VERSION="v2.1.0.2"
-ENV RSTUDIO_VERSION="2024.04.2+764"
+ENV RSTUDIO_VERSION="latest"
 ENV DEFAULT_USER="rstudio"
 
 COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -58,13 +58,13 @@ if [ "$UBUNTU_CODENAME" = "focal" ]; then
     UBUNTU_CODENAME="bionic"
 fi
 
-if [ "$UBUNTU_CODENAME" = "noble" ]; then
-    UBUNTU_CODENAME="jammy"
-fi
-
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
     if [ "$UBUNTU_CODENAME" = "bionic" ]; then
         UBUNTU_CODENAME="focal"
+    fi
+    if [ "$UBUNTU_CODENAME" = "noble" ]; then
+        # use Jammy link per https://dailies.rstudio.com/links/ - last checked 2024-08-05
+        UBUNTU_CODENAME="jammy"
     fi
     wget "https://rstudio.org/download/latest/${RSTUDIO_VERSION}/server/${UBUNTU_CODENAME}/rstudio-server-latest-${ARCH}.deb" -O "$DOWNLOAD_FILE"
 else

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -33,11 +33,11 @@ apt_install \
     libcurl4-openssl-dev \
     libedit2 \
     libobjc4 \
+    libsqlite3-0 \
     libssl-dev \
     libpq5 \
     psmisc \
     procps \
-    python-setuptools \
     pwgen \
     sudo \
     wget
@@ -56,6 +56,10 @@ fi
 
 if [ "$UBUNTU_CODENAME" = "focal" ]; then
     UBUNTU_CODENAME="bionic"
+fi
+
+if [ "$UBUNTU_CODENAME" = "noble" ]; then
+    UBUNTU_CODENAME="jammy"
 fi
 
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then


### PR DESCRIPTION
Fixes #822 in the sense of getting the image to build on Ubuntu 24.

Does not fix the current runtime failures from Rstudio on R devel (see #822 for details), but should automatically pick up the fix when it's released in a new Rstudio build.

