### PR TITLE
Revert "refactor: remove workaround for old RStudio Sever"

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -51,7 +51,6 @@ if [ "$UBUNTU_CODENAME" = "focal" ]; then
     UBUNTU_CODENAME="bionic"
 fi
 
-# TODO: remove this workaround for Ubuntu 24.04
 if [ "$UBUNTU_CODENAME" = "noble" ]; then
     UBUNTU_CODENAME="jammy"
 fi

--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -51,6 +51,11 @@ if [ "$UBUNTU_CODENAME" = "focal" ]; then
     UBUNTU_CODENAME="bionic"
 fi
 
+# TODO: remove this workaround for Ubuntu 24.04
+if [ "$UBUNTU_CODENAME" = "noble" ]; then
+    UBUNTU_CODENAME="jammy"
+fi
+
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
     if [ "$UBUNTU_CODENAME" = "bionic" ]; then
         UBUNTU_CODENAME="focal"


### PR DESCRIPTION
Reverts rocker-org/rocker-versioned2#863

At least in the current version, the RStudio IDE 2024.09 for noble points to the URL for jammy, so it appears that it is necessary to use the download links for jammy.