### PR TITLE
fix(setup_R): `libzstd-dev` is needed to install `littler` with R-devel

### DIFF
--- a/.github/workflows/r-build-test.yml
+++ b/.github/workflows/r-build-test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: tmp-${{ env.TAG }}
+          name: tmp-${{ matrix.tag }}
           path: tmp
 
   regression-test:

--- a/scripts/setup_R.sh
+++ b/scripts/setup_R.sh
@@ -58,6 +58,7 @@ if [ ! -x "$(command -v r)" ]; then
         liblzma-dev \
         libbz2-dev \
         zlib1g-dev \
+        libzstd-dev \
         libicu-dev"
 
     if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then


### PR DESCRIPTION
Fix #898