### PR TITLE
fix path to download latest shiny-server

### DIFF
--- a/scripts/install_shiny_server.sh
+++ b/scripts/install_shiny_server.sh
@@ -33,10 +33,10 @@ apt_install \
 # Install Shiny server
 
 if [ "$SHINY_SERVER_VERSION" = "latest" ]; then
-    SHINY_SERVER_VERSION=$(wget -qO- https://download3.rstudio.org/ubuntu-18.04/x86_64/VERSION)
+    SHINY_SERVER_VERSION=$(wget -qO- https://download3.rstudio.org/ubuntu-20.04/x86_64/VERSION)
 fi
 
-wget --no-verbose "https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-${SHINY_SERVER_VERSION}-amd64.deb" -O ss-latest.deb
+wget --no-verbose "https://download3.rstudio.org/ubuntu-20.04/x86_64/shiny-server-${SHINY_SERVER_VERSION}-amd64.deb" -O ss-latest.deb
 gdebi -n ss-latest.deb
 rm ss-latest.deb
 


### PR DESCRIPTION
Download url of latest shiny server version has changed from download3.rstudio.org/ubuntu-18.04/... to download3.rstudio.org/ubuntu-20.04/...  
(fix rocker-org/rocker-versioned2#904)