### PR TITLE
docs: fix dead link

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,6 +1,6 @@
 # Dockerfiles for container images on Docker Hub
 
-:warning: Dockerfiles in this directory are generated from the stack files by [`make-dockerfiles.R`](../build/make-dockerfiles.R). **Don't edit manually.** :warning:
+:warning: Dockerfiles in this directory are generated from the stack files by [`generate-dockerfiles.R`](../build/scripts/generate-dockerfiles.R). **Don't edit manually.** :warning:
 
 ## Build container images by yourself
 


### PR DESCRIPTION
## Description
The link in [Dockerfiles for container images on Docker Hub](https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/README.md?plain=1#L3) line is not working. I get a 404 code.

## Solution
@eitsupi kindly [pointed](https://github.com/rocker-org/rocker-versioned2/issues/926#issuecomment-2903201444) that the link should point to [generate-dockerfiles.R](build/scripts/generate-dockerfiles.R) .
This should close #926.