### PR TITLE
ci(wiki): `fs::fs_path` can't be treated as character

### DIFF
--- a/build/reports/wiki_home.Rmd
+++ b/build/reports/wiki_home.Rmd
@@ -48,6 +48,7 @@ df_definitions <- fs::dir_ls(
   path = "bakefiles",
   regexp = r"(.+\.docker-bake.json$)"
 ) |>
+  as.character() |>
   tibble::tibble(file = _) |>
   dplyr::arrange(
     stringr::str_extract(file, r"(\d+\.\d+\.\d+)") |>


### PR DESCRIPTION
Fix #976