### PR TITLE
add libuv1-dev for fs package system dependency

### DIFF
--- a/scripts/install_tidyverse.sh
+++ b/scripts/install_tidyverse.sh
@@ -33,6 +33,7 @@ apt_install \
     libtiff5-dev \
     libjpeg-dev \
     unixodbc-dev \
+    libuv1-dev \
     xz-utils
 
 install2.r --error --skipinstalled -n "$NCPUS" \


### PR DESCRIPTION
## Summary

- Adds `libuv1-dev` to the `apt_install` block in `scripts/install_tidyverse.sh`
- The `fs` R package (a transitive dependency of tidyverse/devtools) now requires libuv for some operations

## Test plan

- [ ] Build the tidyverse image and verify `library(fs)` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)