### PR TITLE
fix(texlive): add amsfonts package to tlmgr install list

### DIFF
--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -56,6 +56,7 @@ tlmgr update --self
 tlmgr install latex-bin luatex xetex
 tlmgr install \
     ae \
+    amsfonts \
     amsmath \
     auxhook \
     bibtex \


### PR DESCRIPTION
Closes #973.

Reporter `arnauddeblic` walked through the failure on `rocker/verse:4.5.2` ([thread](https://github.com/rocker-org/rocker-versioned2/issues/973#issuecomment-3118611025)) and identified that `amssymb.sty` is missing from the image. `amssymb.sty` ships in the `amsfonts` package, which isn't in the tlmgr list at `scripts/install_texlive.sh:57`. `amsmath` is already there, but it's a separate CTAN package (math typesetting macros), not a parent of `amsfonts`.

## What this changes

```diff
 tlmgr install \
     ae \
+    amsfonts \
     amsmath \
     auxhook \
```

One line. Slot is alphabetic between `ae` and `amsmath`.

## Why not the larger fix

cboettig + eddelbuettel proposed dropping the tlmgr route in favor of Debian-packaged texlive. That's a meaningful direction change with footprint and breakage tradeoffs to think through; this PR doesn't preempt it. It just unblocks the immediate `Rmd -> PDF` failure path so users on `verse:4.5.2` aren't stuck while the larger discussion continues.

## What I haven't included

- `fontspec`, `l3packages`, `unicode-math` (xelatex-side suggestions from the same comment) — those address a separate engine path the OP didn't actually need; happy to add in a follow-up if you'd like them.