### PR TITLE
ci: fix R devel digest push

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -64,11 +64,13 @@ jobs:
             r-ver.cache-from=type=gha,scope=svn-revision-${{ needs.check-revision.outputs.svn-revision }}-rstudio-${{ matrix.pair }}
             r-ver.cache-from=type=gha,scope=svn-revision-${{ needs.check-revision.outputs.svn-revision }}-tidyverse-${{ matrix.pair }}
             r-ver.cache-to=type=gha,scope=svn-revision-${{ needs.check-revision.outputs.svn-revision }}-r-ver-${{ matrix.pair }}
+            r-ver.tags=
             r-ver.output=type=image,name=docker.io/rocker/r-ver,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
-          DIGEST: ${{ fromJSON(steps.bake.outputs.metadata)['r-ver']['containerimage.digest'] }}
+          METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
+          DIGEST="$(jq -er '."r-ver"."containerimage.digest"' <<<"${METADATA}")"
           mkdir -p "${{ runner.temp }}/digests"
           touch "${{ runner.temp }}/digests/${DIGEST}"
       - name: Upload digest


### PR DESCRIPTION
Follow-up to #1015.

The first scheduled run failed after the image build because the Bake target still supplied `docker.io/rocker/r-ver:devel` while the exporter used `push-by-digest=true`. BuildKit rejects a tagged reference in this mode.

This change:

- clears the Bake target tags for the per-platform digest push
- keeps the repository-only exporter name used for canonical digest references
- parses the successful Bake metadata with `jq -e` in the export step, avoiding the secondary `fromJSON` template error when the build fails

Validation:

- parsed `.github/workflows/devel.yml` with the R `yaml` package
- verified the resolved Bake target has no tags and enables `push-by-digest`
- verified metadata digest extraction
- ran `git diff --check`

Failed run: https://github.com/rocker-org/rocker-versioned2/actions/runs/28342107793/job/83958415286