### PR TITLE
ci: fix digest artifact filenames

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -71,6 +71,8 @@ jobs:
           METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
           DIGEST="$(jq -er '."r-ver"."containerimage.digest"' <<<"${METADATA}")"
+          DIGEST="${DIGEST#sha256:}"
+          [[ "${DIGEST}" =~ ^[0-9a-f]{64}$ ]]
           mkdir -p "${{ runner.temp }}/digests"
           touch "${{ runner.temp }}/digests/${DIGEST}"
       - name: Upload digest
@@ -102,7 +104,7 @@ jobs:
       - name: Create multi-platform manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
-          printf 'docker.io/rocker/r-ver@%s\n' * \
+          printf 'docker.io/rocker/r-ver@sha256:%s\n' * \
             | xargs docker buildx imagetools create \
               --tag docker.io/rocker/r-ver:devel
       - name: Inspect multi-platform manifest


### PR DESCRIPTION
Follow-up to #1017.

Run 28366755776 confirmed that the R image build, canonical digest push, cache export, and metadata extraction now succeed. The job then failed because `actions/upload-artifact@v7` rejects the colon in a filename such as `sha256:616cf1...`.

This change follows Docker's documented distributed multi-platform workflow exactly for digest transport:

- strip the `sha256:` prefix before using the digest as an artifact filename
- validate that the filename is a 64-character lowercase hexadecimal digest
- restore `@sha256:` when constructing source references for `imagetools create`

Reference:
https://github.com/docker/docs/blob/70d0c07c698bfc18bbe08b44c85f9dc859bd7718/content/manuals/build/ci/github-actions/multi-platform.md

Validation:

- verified the resolved Bake output remains an untagged canonical digest push
- simulated two platform metadata outputs, artifact filenames, and merge source references
- parsed `.github/workflows/devel.yml` with the R `yaml` package
- ran `git diff --check`

Failed run:
https://github.com/rocker-org/rocker-versioned2/actions/runs/28366755776/job/84034464381