### PR TITLE
Map resolute to jammy for RStudio install

### DIFF
--- a/scripts/install_rstudio.sh
+++ b/scripts/install_rstudio.sh
@@ -55,6 +55,10 @@ if [ "$UBUNTU_CODENAME" = "noble" ]; then
     UBUNTU_CODENAME="jammy"
 fi
 
+if [ "$UBUNTU_CODENAME" = "resolute" ]; then
+    UBUNTU_CODENAME="jammy"
+fi
+
 if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
     if [ "$UBUNTU_CODENAME" = "bionic" ]; then
         UBUNTU_CODENAME="focal"


### PR DESCRIPTION
`ubuntu:latest` is now 26.04 LTS (resolute). RStudio publishes no resolute (or noble) deb — only jammy — so the devel build 404s daily on `install_rstudio.sh`. Remap resolute→jammy, matching the existing noble→jammy handling.

Verified: jammy deb installs and runs on a resolute container.

Fixes the daily R-devel rstudio build failure.