### PR TITLE
ci(core): hotfix to preserve core digests across registries

### DIFF
--- a/.github/workflows/core-target.yml
+++ b/.github/workflows/core-target.yml
@@ -76,7 +76,7 @@ jobs:
           password: ${{ github.token }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Build and push canonical platform digests
+      - name: Build and push canonical platform digest
         id: bake
         uses: docker/bake-action@v7
         with:
@@ -94,8 +94,7 @@ jobs:
             ${{ inputs.target }}.cache-from=type=gha,scope=core-${{ inputs.version }}-geospatial-${{ steps.config.outputs.platform_pair }}
             ${{ inputs.target }}.cache-to=type=gha,scope=core-${{ inputs.version }}-${{ inputs.target }}-${{ steps.config.outputs.platform_pair }}
             ${{ inputs.target }}.tags=
-            ${{ inputs.target }}.output=type=image,name=${{ steps.config.outputs.docker_repository }},push-by-digest=true,name-canonical=true,push=true
-            ${{ inputs.target }}.output=type=image,name=${{ steps.config.outputs.ghcr_repository }},push-by-digest=true,name-canonical=true,push=true
+            ${{ inputs.target }}.output=type=image,"name=${{ steps.config.outputs.docker_repository }},${{ steps.config.outputs.ghcr_repository }}",push-by-digest=true,name-canonical=true,push=true
       - name: Write digest metadata
         env:
           METADATA: ${{ steps.bake.outputs.metadata }}

--- a/build/scripts/test-core-publish.sh
+++ b/build/scripts/test-core-publish.sh
@@ -58,5 +58,7 @@ export -f docker
 [[ "$(wc -l <"${MOCK_DOCKER_LOG}")" -eq 2 ]]
 grep -q -- "--tag docker.io/rocker/r-ver:${VERSION}" "${MOCK_DOCKER_LOG}"
 grep -q -- '--tag ghcr.io/rocker-org/r-ver:latest' "${MOCK_DOCKER_LOG}"
+grep -q -- "docker.io/rocker/r-ver@${DIGEST}" "${MOCK_DOCKER_LOG}"
+grep -q -- "ghcr.io/rocker-org/r-ver@${DIGEST}" "${MOCK_DOCKER_LOG}"
 
 echo "core publish metadata tests passed"

--- a/build/scripts/test-core-workflow.sh
+++ b/build/scripts/test-core-workflow.sh
@@ -65,6 +65,22 @@ grep -Fq ".target[\$target].platforms" "${TARGET_WORKFLOW}" || {
     exit 1
 }
 
+[[ "$(grep -c 'uses: docker/bake-action@v7' "${TARGET_WORKFLOW}")" -eq 1 ]] || {
+    echo "core reusable workflow must invoke Bake exactly once" >&2
+    exit 1
+}
+mapfile -t image_outputs < <(grep '\.output=type=image' "${TARGET_WORKFLOW}")
+[[ "${#image_outputs[@]}" -eq 1 ]] || {
+    echo "core reusable workflow must use exactly one image exporter" >&2
+    exit 1
+}
+expected_output='            ${{ inputs.target }}.output=type=image,"name=${{ steps.config.outputs.docker_repository }},${{ steps.config.outputs.ghcr_repository }}",push-by-digest=true,name-canonical=true,push=true'
+[[ "${image_outputs[0]}" == "${expected_output}" ]] || {
+    echo "core image exporter must push one shared canonical digest to Docker Hub and GHCR" >&2
+    exit 1
+}
+grep -Fq 'METADATA: ${{ steps.bake.outputs.metadata }}' "${TARGET_WORKFLOW}"
+
 expected_pairs=$(jq -r '.group[0].default[0].targets[] as $target
     | .target[$target].platforms[] | $target + " " + .' "${TEMPLATE}")
 actual_pairs=$(awk '


### PR DESCRIPTION
A follow up for #1030